### PR TITLE
Add troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ We're thinking of extending ZACS to defining styles, so that you can declare sty
 
 ## Troubleshooting
 
-WIP - Please contribute!
+- If you are facing `Error: zacs.viewmethod called directly (not transpiled).'` it might be caused by an incorrect import statement. Currently ZACS is limited to handle only lowercase name (`import zacs from '@nozbe/zacs'`).
 
 ## Contributing
 


### PR DESCRIPTION
This PR starts troubleshooting section with info about error caused by unrecognized `zacs` import name.

It would be desirable to handle it with an error.