### PR TITLE
ZACS 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Strip ZACS declarations (`const Foo = zacs.foo(...)`) and ZACS import from output code by default. Pass `keepDeclarations: true` in Babel config to revert to previous behavior.
 - Fix buggy behavior on `zacs.createXXX` components with both `zacs:inherit` and `zacs:style` props whitelisted
 - Improved validation and error messages
+- Improved Flow typing (likely to reveal new errors)
 
 ## 0.9.3 (2019-09-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 - You can now declare multiple unconditional styles by passing an array of stylesets/class names
 - You can now add extra styles to a ZACS component via `zacs:style={{ attr: value }}` syntax
-- Strip ZACS declarations (`const Foo = zacs.foo(...)`) from output code by default. Pass `keepDeclarations: true` in Babel config to revert to previous behavior
+- Strip ZACS declarations (`const Foo = zacs.foo(...)`) and ZACS import from output code by default. Pass `keepDeclarations: true` in Babel config to revert to previous behavior.
+- Fix buggy behavior on `zacs.createXXX` components with both `zacs:inherit` and `zacs:style` props whitelisted
+- Improved validation and error messages
 
 ## 0.9.3 (2019-09-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- You can now declare multiple unconditional styles by passing an array of stylesets/class names
 - You can now add extra styles to a ZACS component via `zacs:style={{ attr: value }}` syntax
 - Strip ZACS declarations (`const Foo = zacs.foo(...)`) from output code by default. Pass `keepDeclarations: true` in Babel config to revert to previous behavior
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,34 @@ const rendered = <Box zacs:style={{ width: 100, color: '#80EADC' }} />
 This is equivalent to the example above, but instead of predefining list of props that turn into styles,
 we pass styles directly. Note that this only works on ZACS components.
 
+### Multiple unconditional styles
+
+```js
+import styles from './styles'
+
+const TitleText = zacs.text([styles.text, styles.titleText])
+
+const rendered = <TitleText />
+```
+
+<details>
+  <summary>See compiled output</summary>
+
+  **Web:**
+
+  ```js
+  const rendered = <span className={styles.text + ' ' + styles.titleText} />
+  ```
+
+  **React Native:**
+
+  ```js
+  import { Text } from 'react-native'
+
+  const rendered = <Text style={[styles.text, styles.titleText]} />
+  ```
+</details>
+
 ### Styling custom components
 
 ```js
@@ -273,8 +301,6 @@ export default const Touchable = props => {
   return <Root zacs:inherit={props} />
 }
 ```
-
-**TODO:** I don't love the `zacs:inherit` name — if you have a better suggestion, let us know!
 
 <details>
   <summary>See compiled output</summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "0.10.0-1",
+  "version": "1.0.0-0",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "flow": "flow check",
     "eslint": "eslint ./src -c ./.eslintrc.yml --cache --cache-location ./.cache/.eslintcache",
-    "playground": "jest --testMatch='**/__playground__/index.js' --watch",
+    "playground": "chokidar \"src/babel/**/*.js\" --initial -c \"node src/babel/__playground__/index.js\"",
     "prettier": "prettier-eslint --config ./.prettierrc --write \"./src/**/*.js\"",
     "ci:check": "concurrently 'npm run test' 'npm run eslint' 'npm run flow' --kill-others-on-fail"
   },
@@ -52,6 +52,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "chalk": "^4.1.0",
+    "chokidar-cli": "^2.1.0",
     "cli-highlight": "^2.1.4",
     "concurrently": "^4.1.2",
     "eslint": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "flow": "flow check",
     "eslint": "eslint ./src -c ./.eslintrc.yml --cache --cache-location ./.cache/.eslintcache",
+    "playground": "jest --testMatch='**/__playground__/index.js' --watch",
     "prettier": "prettier-eslint --config ./.prettierrc --write \"./src/**/*.js\"",
     "ci:check": "concurrently 'npm run test' 'npm run eslint' 'npm run flow' --kill-others-on-fail"
   },
@@ -50,6 +51,8 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",
+    "chalk": "^4.1.0",
+    "cli-highlight": "^2.1.4",
     "concurrently": "^4.1.2",
     "eslint": "^6.3.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/src/babel/__playground__/index.js
+++ b/src/babel/__playground__/index.js
@@ -1,0 +1,23 @@
+const babel = require('@babel/core')
+const path = require('path')
+const fs = require('fs')
+const { highlight } = require('cli-highlight')
+const plugin = require('../index')
+
+function transform(input, platform, extra = {}) {
+  const { code } = babel.transform(input, {
+    configFile: false,
+    plugins: ['@babel/plugin-syntax-jsx', [plugin, { platform, ...extra }]],
+  })
+  return code
+}
+
+describe('ZACS playground', () => {
+  it('Running playground…', () => {
+    const playground = fs.readFileSync(path.resolve(__dirname, 'playground.js')).toString()
+    const transformed = transform(playground, 'web')
+
+    // eslint-disable-next-line no-console
+    console.log(highlight(transformed, { language: 'javascript' }))
+  })
+})

--- a/src/babel/__playground__/index.js
+++ b/src/babel/__playground__/index.js
@@ -1,5 +1,6 @@
 const babel = require('@babel/core')
 const path = require('path')
+const chalk = require('chalk')
 const fs = require('fs')
 const { highlight } = require('cli-highlight')
 const plugin = require('../index')
@@ -12,12 +13,36 @@ function transform(input, platform, extra = {}) {
   return code
 }
 
-describe('ZACS playground', () => {
-  it('Running playground…', () => {
-    const playground = fs.readFileSync(path.resolve(__dirname, 'playground.js')).toString()
-    const transformed = transform(playground, 'web')
-
-    // eslint-disable-next-line no-console
-    console.log(highlight(transformed, { language: 'javascript' }))
-  })
+// change console.{log,warn,error} so that it shows up differently
+;['log', 'error', 'warn'].forEach(method => {
+  // eslint-disable-next-line
+  const orig = console[method]
+  // eslint-disable-next-line
+  console[method] = (...args) => {
+    switch (method) {
+      case 'log':
+        process.stdout.write(chalk.blue('\n\x07  ===>  console.log <===   \n'))
+        break
+      case 'warn':
+        process.stdout.write(chalk.yellow('\n\x07  ===>  console.process <===   \n'))
+        break
+      case 'error':
+        process.stdout.write(chalk.red('\n\x07  ===>  console.error <===   \n'))
+        break
+      default:
+        break
+    }
+    orig(...args)
+    process.stdout.write('\n')
+  }
 })
+
+// clear screen
+process.stdout.write('\u001b[2J\u001b[0;0H')
+
+// print transformed file
+const playground = fs.readFileSync(path.resolve(__dirname, 'playground.js')).toString()
+const transformed = transform(playground, 'web')
+
+// eslint-disable-next-line no-console
+process.stdout.write(highlight(transformed, { language: 'javascript' }))

--- a/src/babel/__playground__/playground.js
+++ b/src/babel/__playground__/playground.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
-import zacs from 'zacs'
+import zacs from '@nozbe/zacs'
 
-const Root = zacs.view(style.root)
+const Root = zacs.view([style.root, style.root2])
+const Root2 = zacs.createView([style.root, style.root2])
 const view = <Root />

--- a/src/babel/__playground__/playground.js
+++ b/src/babel/__playground__/playground.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+import zacs from 'zacs'
+
+const Root = zacs.view(style.root)
+const view = <Root />

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -215,7 +215,9 @@ export const ExportedStylable2 = props => <ZACS_RN_Text style={[style.text, prop
 export const ExportedCombo = React.forwardRef((props, ref) => <NativeCombo style={[style.combo, props.isFoo && style.foo, props.isBar && style.bar, {
   color: props.color,
   height: props.height
-}].concat(props.style || [])} comboProp1={props.comboProp1} comboProp2={props.comboProp2} ref={ref}>{props.children}</NativeCombo>); // Make sure nothing breaks if I use created component in the same file
+}].concat(props.style || [])} comboProp1={props.comboProp1} comboProp2={props.comboProp2} ref={ref}>{props.children}</NativeCombo>); // regression test
+
+export const ExporterZacsStyleInherit = props => <ZACS_RN_View style={[style.foo, props.__zacs_style].concat(props.style || [])}>{props.children}</ZACS_RN_View>; // Make sure nothing breaks if I use created component in the same file
 
 const combo = <ExportedCombo />;
 const combo_props = <ExportedCombo foo bar={bar} height={100} ref={comboRef} />;
@@ -431,7 +433,9 @@ export const ExportedStylable2 = props => <span className={style.text + (props.i
 export const ExportedCombo = React.forwardRef((props, ref) => <WebCombo className={style.combo + (props.isFoo ? \\" \\" + style.foo : \\"\\") + (props.isBar ? \\" \\" + style.bar : \\"\\") + (\\" \\" + (props.className || \\"\\"))} style={Object.assign({
   color: props.color,
   height: props.height
-}, props.style)} comboProp1={props.comboProp1} comboProp2={props.comboProp2} ref={ref}>{props.children}</WebCombo>); // Make sure nothing breaks if I use created component in the same file
+}, props.style)} comboProp1={props.comboProp1} comboProp2={props.comboProp2} ref={ref}>{props.children}</WebCombo>); // regression test
+
+export const ExporterZacsStyleInherit = props => <div className={style.foo + (\\" \\" + (props.className || \\"\\"))} style={Object.assign({}, props.__zacs_style, props.style)}>{props.children}</div>; // Make sure nothing breaks if I use created component in the same file
 
 const combo = <ExportedCombo />;
 const combo_props = <ExportedCombo foo bar={bar} height={100} ref={comboRef} />;

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`zacs doesn't add __zacs_original_name in production 1`] = `
 "/* eslint-disable */
-import zacs from 'zacs';
 const root = <div className={style.root} />;"
 `;
 
@@ -20,7 +19,6 @@ const ZACS_RN_Text = zacsReactNative.Text;
 const ZACS_RN_View = zacsReactNative.View;
 
 /* eslint-disable */
-import zacs from 'zacs';
 
 /* === Different invocations === */
 const view = <ZACS_RN_View style={style.root} __zacs_original_name=\\"Root\\" />;
@@ -238,7 +236,6 @@ const passZacsStyledWithoutDefInherit = <ImportedComponent2 style={props.style} 
 
 exports[`zacs works with the basic example on web 1`] = `
 "/* eslint-disable */
-import zacs from 'zacs';
 
 /* === Different invocations === */
 const view = <div className={style.root} __zacs_original_name=\\"Root\\" />;

--- a/src/babel/__tests__/examples/basic.js
+++ b/src/babel/__tests__/examples/basic.js
@@ -259,6 +259,12 @@ export const ExportedCombo = zacs.createStyled(
   ['comboProp1', 'comboProp2', 'zacs:inherit', 'ref'],
 )
 
+// regression test
+export const ExporterZacsStyleInherit = zacs.createView(style.foo, null, null, [
+  'zacs:style',
+  'zacs:inherit',
+])
+
 // Make sure nothing breaks if I use created component in the same file
 
 const combo = <ExportedCombo />

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -61,4 +61,16 @@ describe('zacs', () => {
       'Duplicate ZACS declaration for name: Foo',
     )
   })
+  it(`imports are validated`, () => {
+    const badForms = [
+      `import Zacs from '@nozbe/zacs'`,
+      `import {text,createView} from '@nozbe/zacs'`,
+      `import * as zacs from '@nozbe/zacs'`,
+      `import ZACS from 'zacs'`,
+    ]
+    badForms.forEach(js => {
+      // console.log(js)
+      expect(() => transform(js, 'web')).toThrow('ZACS import must say exactly')
+    })
+  })
 })

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -815,6 +815,10 @@ exports.default = function(babel) {
         }
 
         validateZacsImport(t, path)
+
+        if (!state.opts.keepDeclarations) {
+          path.remove()
+        }
       },
     },
   }

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-use-before-define */
 // Note: Why is this one big file? Because that makes it possible to work with it using https://astexplorer.net :)
 
-Object.defineProperty(exports, '__esModule', {
-  value: true,
-})
+exports.__esModule = true
 
 /*
 
@@ -73,11 +71,11 @@ function webSafeAttributes(attributes) {
   })
 }
 
-function withoutStylingProps(t, attributes, condStylesets, literalStyleSpec) {
+function withoutStylingProps(t, attributes, condStyles, literalStyleSpec) {
   const stylingProps = []
 
-  if (condStylesets && condStylesets.properties) {
-    condStylesets.properties.forEach(property => {
+  if (condStyles && condStyles.properties) {
+    condStyles.properties.forEach(property => {
       stylingProps.push(property.key.name)
     })
   }
@@ -155,7 +153,7 @@ function findNamespacedAttr(t, attributes, attrName) {
   )
 }
 
-function getStyles(t, uncondStyleset, condStylesets, literalStyleSpec, jsxAttributes, passedProps) {
+function getStyles(t, uncondStyleset, condStyles, literalStyleSpec, jsxAttributes, passedProps) {
   const styles = []
   const literalStyles = []
 
@@ -163,8 +161,8 @@ function getStyles(t, uncondStyleset, condStylesets, literalStyleSpec, jsxAttrib
     styles.push([uncondStyleset])
   }
 
-  if (condStylesets && !t.isNullLiteral(condStylesets)) {
-    condStylesets.properties.forEach(property => {
+  if (condStyles && !t.isNullLiteral(condStyles)) {
+    condStyles.properties.forEach(property => {
       const style = property.value
       const propName = property.key.name
 
@@ -349,7 +347,7 @@ function styleAttributes(
   t,
   platform,
   uncondStyleset,
-  condStylesets,
+  condStyles,
   literalStyleSpec,
   jsxAttributes,
   passedProps = [],
@@ -357,7 +355,7 @@ function styleAttributes(
   const styles = getStyles(
     t,
     uncondStyleset,
-    condStylesets,
+    condStyles,
     literalStyleSpec,
     jsxAttributes,
     passedProps,
@@ -461,7 +459,7 @@ function createZacsComponent(t, state, path) {
     path, // should be path to declaration
     zacsMethod === 'styled' ? init.arguments[0] : zacsMethod,
   )
-  const [uncondStyleset, condStylesets, literalStyleSpec, passedPropsExpr] =
+  const [uncondStyleset, condStyles, literalStyleSpec, passedPropsExpr] =
     zacsMethod === 'styled' ? init.arguments.slice(1) : init.arguments
 
   if (platform === 'native') {
@@ -495,7 +493,7 @@ function createZacsComponent(t, state, path) {
       t,
       platform,
       uncondStyleset,
-      condStylesets,
+      condStyles,
       literalStyleSpec,
       null,
       passedProps,
@@ -579,12 +577,12 @@ function validateZacsDeclaration(t, path) {
     }
   }
 
-  const [, condStylesets, literalStyleSpec] =
+  const [, condStyles, literalStyleSpec] =
     zacsMethod === 'styled' || zacsMethod === 'createStyled'
       ? init.arguments.slice(1)
       : init.arguments
 
-  if (condStylesets && !(t.isObjectExpression(condStylesets) || t.isNullLiteral(condStylesets))) {
+  if (condStyles && !(t.isObjectExpression(condStyles) || t.isNullLiteral(condStyles))) {
     throw path.buildCodeFrameError(
       'Conditional styles (second argument to ZACS) should be an object expression',
     )
@@ -717,7 +715,7 @@ exports.default = function(babel) {
           path, // should be path to declaration
           zacsMethod === 'styled' ? init.arguments[0] : zacsMethod,
         )
-        const [uncondStyleset, condStylesets, literalStyleSpec] =
+        const [uncondStyleset, condStyles, literalStyleSpec] =
           zacsMethod === 'styled' ? init.arguments.slice(1) : init.arguments
         const originalAttributes = openingElement.attributes
 
@@ -733,7 +731,7 @@ exports.default = function(babel) {
         openingElement.attributes = withoutStylingProps(
           t,
           openingElement.attributes,
-          condStylesets,
+          condStyles,
           literalStyleSpec,
         )
 
@@ -762,7 +760,7 @@ exports.default = function(babel) {
             t,
             platform,
             uncondStyleset,
-            condStylesets,
+            condStyles,
             literalStyleSpec,
             originalAttributes,
           ),

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -375,7 +375,7 @@ function styleAttributes(
     case 'native':
       return nativeStyleAttributes(t, styles)
     default:
-      throw new Error('Unknown platform')
+      throw new Error('Unknown platform passed to ZACS config')
   }
 }
 
@@ -557,7 +557,7 @@ function validateZacsDeclaration(t, path) {
     // declarator -> declaration -> export declaration
     if (t.isExportDeclaration(path.parentPath.parent)) {
       throw path.buildCodeFrameError(
-        `It's not allowed to export zacs declarations -- but you can export zacs components (use zacs.createView/createText/createStyled)`,
+        `It's not allowed to export zacs declarations. You can export zacs components (use zacs.createView/createText/createStyled), however they behave a little differently -- please check documentation for more information.`,
       )
     }
   }
@@ -574,7 +574,7 @@ function validateZacsDeclaration(t, path) {
       )
     ) {
       throw path.buildCodeFrameError(
-        'zacs.styled() requires an argument - a `Component`, a `{ web: Component, native: Component }` specifier, or a `"builtin"`',
+        'zacs.styled() requires an argument - a `Component`, a `{ web: Component, native: Component }` specifier, or a `"builtin"` (e.g. `"div"` on web)',
       )
     }
   }

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -5,6 +5,24 @@ Object.defineProperty(exports, '__esModule', {
   value: true,
 })
 
+/*
+
+TERMINOLOGY:
+
+zacs.{view,text,styled}()       -- styled declaration
+zacs.create{View,Text,Styled}() -- styled component
+
+styles.foo                      -- predefined styleset
+{ foo: 'bar' }                  -- literal styleset
+
+zacs.view(
+  styles.foo,                   -- unconditional styleset
+  { bar: styles.bar },          -- conditional styleset spec
+  { width: 'width' }            -- literal style spec
+)
+
+*/
+
 function getPlatform(state) {
   // return 'web'
   // return 'native'

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -275,6 +275,11 @@ function webStyleExpr(t, styles, inheritedProps, zacsStyle) {
     return allStyles[0]
   }
 
+  // prevent Object.assign(props.__zacs_style, ...), because if it's not an object, it will crash
+  if (!styles && zacsStyle && inheritedProps && !t.isObjectExpression(zacsStyle)) {
+    allStyles.unshift(t.objectExpression([]))
+  }
+
   // Object.assign({styles:'values'}, props.style)
   // TODO: Maybe we can use spread operator and babel will transpile it into ES5 if necessary?
   return t.callExpression(

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ function displayZacsError(methodName) {
       throw new Error(
         'zacs.' +
           methodName +
-          'method called directly (not transpiled). Your Babel file is probably misconfigured or you have a syntax error. See https://github.com/Nozbe/zacs#troubleshooting for more info',
+          'method was called directly (was not transpiled into zero-abstraction-cost form). This is an error. Most likely, you have a syntax error, your Babel configuration file is misconfigured, or you incorrectly use ZACS declarations as component objects. See https://github.com/Nozbe/zacs#troubleshooting for more information.',
       )
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ function displayZacsError(methodName) {
       throw new Error(
         'zacs.' +
           methodName +
-          'method was called directly (was not transpiled into zero-abstraction-cost form). This is an error. Most likely, you have a syntax error, your Babel configuration file is misconfigured, or you incorrectly use ZACS declarations as component objects. See https://github.com/Nozbe/zacs#troubleshooting for more information.',
+          'method was called directly (was not transpiled into zero-abstraction-cost form). This is an error. Most likely, you have a syntax error, your Babel configuration file is misconfigured, or you incorrectly use ZACS declarations as component objects. In fact, unless you pass { keepDeclarations: true } to ZACS Babel config, you should never see this file in the compiled app. See https://github.com/Nozbe/zacs#troubleshooting for more information.',
       )
     }
   }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -9,67 +9,72 @@ type ReactNativeStyleSheetId = number
 type ReactNativeStyleObject = Object
 type PredefinedStyle = CSSClassName | ReactNativeStyleSheetId | ReactNativeStyleObject
 
+type UnconditionalStyles = PredefinedStyle | PredefinedStyle[]
+
 type ConditionalStyles = { [propNameThatAddsConditionalStyleIfTruthy: string]: PredefinedStyle }
 
 type StyleAttributeName = CSSPropertyName | ReactNativeStyleAttributeName
 type StyleAttributes = { [propName: string]: StyleAttributeName }
 
 type ZacsViewFunction = (
-  mainStyle: ?PredefinedStyle,
+  unconditionalStyles: ?UnconditionalStyles,
   conditionalStyles: ?ConditionalStyles,
-  styleAttributes: ?StyleAttributes,
+  literalStyles: ?StyleAttributes,
 ) => React$Component<any>
 
 type ZacsTextFunction = (
-  mainStyle: ?PredefinedStyle,
+  unconditionalStyles: ?UnconditionalStyles,
   conditionalStyles: ?ConditionalStyles,
-  styleAttributes: ?StyleAttributes,
+  literalStyles: ?StyleAttributes,
 ) => React$Component<any>
 
 type BuiltinElementName = string
-type ConcreteComponentToStyle = React$Component<any> | BuiltinElementName
-type ComponentPlatformSelect = $Exact<{
-  web: ConcreteComponentToStyle | ZacsViewFunction | ZacsTextFunction,
-  native: ConcreteComponentToStyle | ZacsViewFunction | ZacsTextFunction,
+type ConcreteComponentToStyle<Props> = React$Component<Props> | BuiltinElementName
+type ComponentPlatformSelect<Props> = $Exact<{
+  web: ConcreteComponentToStyle<Props> | ZacsViewFunction | ZacsTextFunction,
+  native: ConcreteComponentToStyle<Props> | ZacsViewFunction | ZacsTextFunction,
 }>
-type ComponentToStyle = ConcreteComponentToStyle | ComponentPlatformSelect
+type ComponentToStyle<Props> = ConcreteComponentToStyle<Props> | ComponentPlatformSelect<Props>
 
-type WhitelistedPropNames = Array<'ref' | 'zacs:inherit' | string>
+type ZacsStyledFunction = <Props>(
+  componentToStyle: ComponentToStyle<Props>,
+  unconditionalStyles: ?UnconditionalStyles,
+  conditionalStyles: ?ConditionalStyles,
+  literalStyles: ?StyleAttributes,
+) => React$Component<{ ...Props, ... }>
+
+type ZacsCreateViewFunction = (
+  unconditionalStyles: ?UnconditionalStyles,
+  conditionalStyles: ?ConditionalStyles,
+  literalStyles: ?StyleAttributes,
+  whitelistedProps: ?WhitelistedPropNames,
+) => React$Component<any>
+
+type ZacsCreateTextFunction = (
+  unconditionalStyles: ?UnconditionalStyles,
+  conditionalStyles: ?ConditionalStyles,
+  literalStyles: ?StyleAttributes,
+  whitelistedProps: ?WhitelistedPropNames,
+) => React$Component<any>
+
+type ZacsCreateStyledFunction = <Props>(
+  componentToStyle: ComponentToStyle<Props>,
+  unconditionalStyles: ?UnconditionalStyles,
+  conditionalStyles: ?ConditionalStyles,
+  literalStyles: ?StyleAttributes,
+  whitelistedProps: ?WhitelistedPropNames,
+) => React$Component<{ ...Props, ... }>
+
+type WhitelistedPropNames = Array<'ref' | 'zacs:inherit' | 'zacs:style' | string>
 
 declare export default {
   // TODO: Return components with the right prop types typed out (inherit prop types from component being styles + add conditionalStyles & style attributes)
   view: ZacsViewFunction,
-
   text: ZacsTextFunction,
-
-  styled: (
-    componentToStyle: ComponentToStyle,
-    mainStyle: ?PredefinedStyle,
-    conditionalStyles: ?ConditionalStyles,
-    styleAttributes: ?StyleAttributes,
-  ) => React$Component<any>,
-
-  createView: (
-    mainStyle: ?PredefinedStyle,
-    conditionalStyles: ?ConditionalStyles,
-    styleAttributes: ?StyleAttributes,
-    whitelistedProps: ?WhitelistedPropNames,
-  ) => React$Component<any>,
-
-  createText: (
-    mainStyle: ?PredefinedStyle,
-    conditionalStyles: ?ConditionalStyles,
-    styleAttributes: ?StyleAttributes,
-    whitelistedProps: ?WhitelistedPropNames,
-  ) => React$Component<any>,
-
-  createStyled: (
-    componentToStyle: ComponentToStyle,
-    mainStyle: ?PredefinedStyle,
-    conditionalStyles: ?ConditionalStyles,
-    styleAttributes: ?StyleAttributes,
-    whitelistedProps: ?WhitelistedPropNames,
-  ) => React$Component<any>,
+  styled: ZacsStyledFunction,
+  createView: ZacsCreateViewFunction,
+  createText: ZacsCreateTextFunction,
+  createStyled: ZacsCreateStyledFunction,
 }
 
 type ReactNativeStyleAttributeName =

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,6 +588,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
 ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
@@ -595,6 +602,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -938,6 +950,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -980,6 +1000,18 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-highlight@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.4.tgz#098cb642cf17f42adc1c1145e07f960ec4d7522b"
+  integrity sha512-s7Zofobm20qriqDoU9sXptQx0t2R9PEgac92mENNm7xaEe1hn71IIMsXMK+6encA6WRCWWxIGQbipr3q998tlQ==
+  dependencies:
+    chalk "^3.0.0"
+    highlight.js "^9.6.0"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^5.1.1"
+    yargs "^15.0.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -1007,6 +1039,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -2079,6 +2120,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+highlight.js@^9.6.0:
+  version "9.18.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"
+  integrity sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==
 
 hosted-git-info@^2.1.4:
   version "2.8.8"
@@ -3252,6 +3298,15 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nan@^2.12.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
@@ -3344,7 +3399,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3570,10 +3625,22 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse5-htmlparser2-tree-adapter@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.1.tgz#e8c743d4e92194d5293ecde2b08be31e67461cbc"
+  integrity sha512-CF+TKjXqoqyDwHqBhFQ+3l5t83xYi6fVT1tQNg+Ye0JRLnTxWvIroCjEp1A0k4lneHNBGnICUf0cfYVYGEazqw==
+  dependencies:
+    parse5 "^5.1.1"
+
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -4350,7 +4417,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -4497,6 +4564,20 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -4786,6 +4867,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -4840,6 +4930,14 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
@@ -4873,3 +4971,20 @@ yargs@^13.2.4, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^15.0.0:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,6 +616,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -824,6 +832,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -859,6 +872,13 @@ braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+braces@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -970,6 +990,31 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chokidar-cli@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chokidar-cli/-/chokidar-cli-2.1.0.tgz#2491df133bd62cd145227b1746fbd94f2733e1bc"
+  integrity sha512-6n21AVpW6ywuEPoxJcLXMA2p4T+SLjWsXKny/9yTWFz0kKxESI3eUylpeV97LylING/27T/RVTY0f2/0QaWq9Q==
+  dependencies:
+    chokidar "^3.2.3"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    yargs "^13.3.0"
+
+chokidar@^3.2.3:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1868,6 +1913,13 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -1948,6 +2000,11 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
+fsevents@~2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -2002,7 +2059,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.0.0:
+glob-parent@^5.0.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -2286,6 +2343,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -2379,7 +2443,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -2392,6 +2456,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -3086,6 +3155,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3100,6 +3174,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash.unescape@4.0.1:
   version "4.0.1"
@@ -3376,6 +3455,11 @@ normalize-path@^2.1.1:
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -3696,6 +3780,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picomatch@^2.0.4, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -3925,6 +4014,13 @@ read-pkg@^4.0.1:
     normalize-package-data "^2.3.2"
     parse-json "^4.0.0"
     pify "^3.0.0"
+
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -4620,6 +4716,13 @@ to-regex-range@^2.1.0:
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
- Added a simple playground environment. The hope is that it works nicely enough that I don't need https://astexplorer.net to efficiently play around with changes -- if this proves out while implementing new features, I'll split up the one huge babel plugin file into multiple, easier to understand files.
- Add the ability to declare multiple unconditional style sets, eg. `zacs.view([styles.text, styles.titleText], ...)`
- Slight refactoring, update docs
- Fix buggy behavior on `zacs.createXXX` components with both `zacs:inherit` and `zacs:style` props whitelisted
- Improved validation and error messages
- Improved Flow typing (likely to reveal new errors)
- Strip ZACS imports from production code