### PR TITLE
Experimental Stylesheets, Part 2

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/webpack/loader')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-7",
+  "version": "1.1.0-8",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-5",
+  "version": "1.1.0-6",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-4",
+  "version": "1.1.0-5",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-6",
+  "version": "1.1.0-7",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-2",
+  "version": "1.1.0-4",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {
@@ -16,6 +16,8 @@
     "src/index.js.flow",
     "src/babel/index.js",
     "babel.js",
+    "src/webpack/loader.js",
+    "loader.js",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -23,7 +23,11 @@ If you only see this comment and the one below in generated code, this is normal
 const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\`
 .root {
   background-color: red;
-  height: 100;
+  height: 50px;
+  width: 100%;
+  flex: 1;
+  z-index: 1000;
+  -webkit-padding-start: 20px;
 }
 ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\`;
 /* ZACS-generated CSS stylesheet ends above */"

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -25,7 +25,7 @@ const styles = ZACS_RN_StyleSheet.create({
     width: '100%',
     flex: 1,
     zIndex: 1000,
-    WebkitPaddingStart: 20
+    width: 1337
   },
   text: {
     color: '#abcdef',
@@ -53,6 +53,8 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\`
   flex: 1;
   z-index: 1000;
   -webkit-padding-start: 20px;
+  z-index: 1500;
+  & > span { opacity: 0.5 }
 }
 
 .text {

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -32,7 +32,8 @@ const styles = ZACS_RN_StyleSheet.create({
     fontSize: 12,
     fontWeight: 'bold',
     paddingLeft: 20,
-    paddingRight: 20
+    paddingRight: 20,
+    opacity: 0.5
   }
 });"
 `;
@@ -58,7 +59,8 @@ const styles = ZACS_RN_StyleSheet.create({
     fontSize: 12,
     fontWeight: 'bold',
     paddingLeft: 20,
-    paddingRight: 20
+    paddingRight: 20,
+    opacity: 0.5
   }
 });"
 `;
@@ -84,7 +86,8 @@ const styles = ZACS_RN_StyleSheet.create({
     fontSize: 12,
     fontWeight: 'bold',
     paddingLeft: 20,
-    paddingRight: 20
+    paddingRight: 20,
+    opacity: 0.5
   }
 });"
 `;
@@ -115,6 +118,11 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\`
   font-weight: bold;
   padding-left: 20px;
   padding-right: 20px;
+  opacity: 0.5;
+  &:hover {
+      opacity: .8;
+      color: #abbaba;
+    }
 }
 ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\`;
 /* ZACS-generated CSS stylesheet ends above */"

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -37,6 +37,58 @@ const styles = ZACS_RN_StyleSheet.create({
 });"
 `;
 
+exports[`zacs transforms experimental stylesheets (native, android) 1`] = `
+"const zacsReactNative = require('react-native');
+
+const ZACS_RN_StyleSheet = zacsReactNative.StyleSheet;
+
+/* eslint-disable */
+const styles = ZACS_RN_StyleSheet.create({
+  root: {
+    backgroundColor: 'red',
+    height: 50,
+    width: '100%',
+    flex: 1,
+    zIndex: 1000,
+    width: 1337,
+    opacity: 0.1
+  },
+  text: {
+    color: '#abcdef',
+    fontSize: 12,
+    fontWeight: 'bold',
+    paddingLeft: 20,
+    paddingRight: 20
+  }
+});"
+`;
+
+exports[`zacs transforms experimental stylesheets (native, ios) 1`] = `
+"const zacsReactNative = require('react-native');
+
+const ZACS_RN_StyleSheet = zacsReactNative.StyleSheet;
+
+/* eslint-disable */
+const styles = ZACS_RN_StyleSheet.create({
+  root: {
+    backgroundColor: 'red',
+    height: 50,
+    width: '100%',
+    flex: 1,
+    zIndex: 1000,
+    width: 1337,
+    width: 2137
+  },
+  text: {
+    color: '#abcdef',
+    fontSize: 12,
+    fontWeight: 'bold',
+    paddingLeft: 20,
+    paddingRight: 20
+  }
+});"
+`;
+
 exports[`zacs transforms experimental stylesheets (web) 1`] = `
 "/*
 ZACS-generated CSS stylesheet begins below.

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -100,7 +100,7 @@ If you only see this comment and the one below in generated code, this is normal
 */
 
 /* eslint-disable */
-const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\`
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\`
 .root {
   background-color: red;
   height: 50px;
@@ -124,7 +124,7 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\`
       color: #abbaba;
     }
 }
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\`;
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\`);
 /* ZACS-generated CSS stylesheet ends above */"
 `;
 

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -100,31 +100,31 @@ If you only see this comment and the one below in generated code, this is normal
 */
 
 /* eslint-disable */
-const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\`
-.root {
-  background-color: red;
-  height: 50px;
-  width: 100%;
-  flex: 1;
-  z-index: 1000;
-  -webkit-padding-start: 20px;
-  z-index: 1500;
-  & > span { opacity: 0.5 }
-}
-
-.text {
-  color: #abcdef;
-  font-size: 12px;
-  font-weight: bold;
-  padding-left: 20px;
-  padding-right: 20px;
-  opacity: 0.5;
-  &:hover {
-      opacity: .8;
-      color: #abbaba;
-    }
-}
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\`);
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\\" \\\\n\\\\
+.root { \\\\n\\\\
+  background-color: red; \\\\n\\\\
+  height: 50px; \\\\n\\\\
+  width: 100%; \\\\n\\\\
+  flex: 1; \\\\n\\\\
+  z-index: 1000; \\\\n\\\\
+  -webkit-padding-start: 20px; \\\\n\\\\
+  z-index: 1500; \\\\n\\\\
+  & > span { opacity: 0.5 } \\\\n\\\\
+} \\\\n\\\\
+ \\\\n\\\\
+.text { \\\\n\\\\
+  color: #abcdef; \\\\n\\\\
+  font-size: 12px; \\\\n\\\\
+  font-weight: bold; \\\\n\\\\
+  padding-left: 20px; \\\\n\\\\
+  padding-right: 20px; \\\\n\\\\
+  opacity: 0.5; \\\\n\\\\
+  &:hover { \\\\n\\\\
+      opacity: .8; \\\\n\\\\
+      color: #abbaba; \\\\n\\\\
+    } \\\\n\\\\
+} \\\\n\\\\
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\\");
 /* ZACS-generated CSS stylesheet ends above */"
 `;
 

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -12,7 +12,32 @@ const Root = zacs.view(style.root);
 const root = <div className={style.root} />;"
 `;
 
-exports[`zacs transforms experimental stylesheets 1`] = `
+exports[`zacs transforms experimental stylesheets (native) 1`] = `
+"const zacsReactNative = require('react-native');
+
+const ZACS_RN_StyleSheet = zacsReactNative.StyleSheet;
+
+/* eslint-disable */
+const styles = ZACS_RN_StyleSheet.create({
+  root: {
+    backgroundColor: 'red',
+    height: 50,
+    width: '100%',
+    flex: 1,
+    zIndex: 1000,
+    WebkitPaddingStart: 20
+  },
+  text: {
+    color: '#abcdef',
+    fontSize: 12,
+    fontWeight: 'bold',
+    paddingLeft: 20,
+    paddingRight: 20
+  }
+});"
+`;
+
+exports[`zacs transforms experimental stylesheets (web) 1`] = `
 "/*
 ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
@@ -28,6 +53,14 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\`
   flex: 1;
   z-index: 1000;
   -webkit-padding-start: 20px;
+}
+
+.text {
+  color: #abcdef;
+  font-size: 12px;
+  font-weight: bold;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\`;
 /* ZACS-generated CSS stylesheet ends above */"

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -19,7 +19,7 @@ const styles = zacs._experimentalStyleSheet({
       width: 2137,
     },
     android: {
-      opacity: 0.1
+      opacity: 0.1,
     },
     css: '& > span { opacity: 0.5 }',
   },
@@ -33,6 +33,6 @@ const styles = zacs._experimentalStyleSheet({
     css: `&:hover {
       opacity: .8;
       color: #abbaba;
-    }`
+    }`,
   },
 })

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -10,7 +10,18 @@ const styles = zacs._experimentalStyleSheet({
     zIndex: 1000,
     web: {
       WebkitPaddingStart: 20,
+      zIndex: 1500,
     },
+    native: {
+      width: 1337,
+    },
+    ios: {
+      width: 2137,
+    },
+    android: {
+      opacity: 0.1
+    },
+    css: '& > span { opacity: 0.5 }',
   },
   text: {
     color: '#abcdef',

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -29,5 +29,10 @@ const styles = zacs._experimentalStyleSheet({
     fontWeight: 'bold',
     paddingLeft: 20,
     paddingRight: 20,
+    opacity: 0.5,
+    css: `&:hover {
+      opacity: .8;
+      color: #abbaba;
+    }`
   },
 })

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -8,7 +8,9 @@ const styles = zacs._experimentalStyleSheet({
     width: '100%',
     flex: 1,
     zIndex: 1000,
-    WebkitPaddingStart: 20,
+    web: {
+      WebkitPaddingStart: 20,
+    },
   },
   text: {
     color: '#abcdef',

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -10,4 +10,11 @@ const styles = zacs._experimentalStyleSheet({
     zIndex: 1000,
     WebkitPaddingStart: 20,
   },
+  text: {
+    color: '#abcdef',
+    fontSize: 12,
+    fontWeight: 'bold',
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
 })

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -4,6 +4,10 @@ import zacs from 'zacs'
 const styles = zacs._experimentalStyleSheet({
   root: {
     backgroundColor: 'red',
-    height: 100,
+    height: 50,
+    width: '100%',
+    flex: 1,
+    zIndex: 1000,
+    WebkitPaddingStart: 20,
   },
 })

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -73,7 +73,10 @@ describe('zacs', () => {
       expect(() => transform(js, 'web')).toThrow('ZACS import must say exactly')
     })
   })
-  it(`transforms experimental stylesheets`, () => {
+  it(`transforms experimental stylesheets (web)`, () => {
     expect(transform(example('stylesheet'), 'web')).toMatchSnapshot()
+  })
+  it(`transforms experimental stylesheets (native)`, () => {
+    expect(transform(example('stylesheet'), 'native')).toMatchSnapshot()
   })
 })

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -85,4 +85,46 @@ describe('zacs', () => {
   it(`transforms experimental stylesheets (native, android)`, () => {
     expect(transform(example('stylesheet'), 'native', { target: 'android' })).toMatchSnapshot()
   })
+  it(`throw an error on illegal stylesheets`, () => {
+    const bad = (syntax, error) => expect(() => transform(`const _ = zacs._experimentalStyleSheet(${syntax})`, 'web')).toThrow(error)
+
+    bad('', 'single Object')
+    bad('[]', 'single Object')
+    bad('styles', 'single Object')
+
+    bad('{"foo":{}}', 'name: {}')
+    bad('{[name]:{}}', 'name: {}')
+    bad('{foo}', 'name: {}')
+    bad('{foo(){}}', 'name: {}')
+    bad('{a:{},...styles}', 'name: {}')
+    bad('{get b(){}}', 'name: {}')
+
+    bad('{a: 0}', 'object literal')
+    bad('{a: x?{}:{}}', 'object literal')
+    bad('{a: styles}', 'object literal')
+    bad('{a: []}', 'object literal')
+    bad('{a: ""}', 'object literal')
+
+    bad('{a: {"foo":0}}', 'simple strings')
+    bad('{a: {[name]:0}}', 'simple strings')
+    bad('{a: {foo:0,...styles}}', 'simple strings')
+    bad('{a: {foo}}', 'simple strings')
+
+    bad('{a: {css:null}}', 'magic css:')
+    bad('{a: {css:predefinedCss}}', 'magic css:')
+    bad('{a: {css:{}}}', 'magic css:')
+    // eslint-disable-next-line no-template-curly-in-string
+    bad('{a: {css:`foo${bar}`}}', 'magic css:')
+
+    bad('{a: {web:{foo}}}', 'simple strings')
+    bad('{a: {native:{...styles}}}', 'simple strings')
+    bad('{a: {ios:{foo}}}', 'simple strings')
+    bad('{a: {android:{foo}}}', 'simple strings')
+
+    bad('{a: { width: width }}', 'strings or numbers')
+    bad('{a: { width: platform ? 10 : 20 }}', 'strings or numbers')
+    bad('{a: { width: null }}', 'strings or numbers')
+    bad('{a: { width: false }}', 'strings or numbers')
+    bad('{a: { width: foo(bar) }}', 'strings or numbers')
+  })
 })

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -79,4 +79,10 @@ describe('zacs', () => {
   it(`transforms experimental stylesheets (native)`, () => {
     expect(transform(example('stylesheet'), 'native')).toMatchSnapshot()
   })
+  it(`transforms experimental stylesheets (native, ios)`, () => {
+    expect(transform(example('stylesheet'), 'native', {target: 'ios'})).toMatchSnapshot()
+  })
+  it(`transforms experimental stylesheets (native, android)`, () => {
+    expect(transform(example('stylesheet'), 'native', {target: 'android'})).toMatchSnapshot()
+  })
 })

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -80,9 +80,9 @@ describe('zacs', () => {
     expect(transform(example('stylesheet'), 'native')).toMatchSnapshot()
   })
   it(`transforms experimental stylesheets (native, ios)`, () => {
-    expect(transform(example('stylesheet'), 'native', {target: 'ios'})).toMatchSnapshot()
+    expect(transform(example('stylesheet'), 'native', { target: 'ios' })).toMatchSnapshot()
   })
   it(`transforms experimental stylesheets (native, android)`, () => {
-    expect(transform(example('stylesheet'), 'native', {target: 'android'})).toMatchSnapshot()
+    expect(transform(example('stylesheet'), 'native', { target: 'android' })).toMatchSnapshot()
   })
 })

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -885,9 +885,9 @@ function transformStyleSheet(t, state, path) {
     const css = encodeCSSStyleSheet(stylesheet)
     const preparedCss = `\n${css}ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
     const magicCssExpression = t.expressionStatement(
-      t.taggedTemplateExpression(
+      t.callExpression(
         t.identifier('ZACS_MAGIC_CSS_STYLESHEET_MARKER_START'),
-        t.templateLiteral([t.templateElement({ raw: preparedCss, cooked: preparedCss })], []),
+        [t.templateLiteral([t.templateElement({ raw: preparedCss, cooked: preparedCss })], [])],
       ),
     )
     t.addComment(

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -29,7 +29,9 @@ function getPlatform(state) {
     throw new Error('platform option is required for ZACS babel plugin')
   }
   if (platform !== 'web' && platform !== 'native') {
-    throw new Error('illegal platform option passed to ZACS babel plugin. allowed values: web, native')
+    throw new Error(
+      'illegal platform option passed to ZACS babel plugin. allowed values: web, native',
+    )
   }
   return platform
 }
@@ -40,7 +42,9 @@ function getTarget(state) {
   const { target } = state.opts
   if (target && !['ios', 'android', 'web'].includes(target)) {
     // eslint-disable-next-line no-console
-    console.warn('Unrecognized target passed to ZACS babel plugin. Known targets: web, ios, android')
+    console.warn(
+      'Unrecognized target passed to ZACS babel plugin. Known targets: web, ios, android',
+    )
   }
   return target
 }
@@ -737,11 +741,7 @@ function isPlainObjectProperty(t, node) {
 }
 
 function isPlainTemplateLiteral(t, node) {
-  return (
-    t.isTemplateLiteral(node) &&
-    !node.expressions.length &&
-    node.quasis.length === 1
-  )
+  return t.isTemplateLiteral(node) && !node.expressions.length && node.quasis.length === 1
 }
 
 function validateStyleset(t, styleset, path) {
@@ -759,7 +759,7 @@ function validateStyleset(t, styleset, path) {
       const key = property.key.name
       const { value } = property
       if (key === 'css') {
-        return t.isStringLiteral(value) ||isPlainTemplateLiteral(t, value)
+        return t.isStringLiteral(value) || isPlainTemplateLiteral(t, value)
       } else if (key === 'web' || key === 'native' || key === 'ios' || key === 'android') {
         validateStyleset(t, value, path)
         return true
@@ -811,7 +811,7 @@ function encodeCSSValue(property, value) {
 }
 
 function encodeCSSStyle(property) {
-  const {value} = property
+  const { value } = property
   const key = property.key.name
   if (key === 'native' || key === 'ios' || key === 'android') {
     return null
@@ -825,7 +825,10 @@ function encodeCSSStyle(property) {
 }
 
 function encodeCSSStyles(styleset) {
-  return styleset.properties.map(encodeCSSStyle).filter(rule => rule !== null).join('\n')
+  return styleset.properties
+    .map(encodeCSSStyle)
+    .filter(rule => rule !== null)
+    .join('\n')
 }
 
 function encodeCSSStyleset(styleset) {

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -884,10 +884,14 @@ function transformStyleSheet(t, state, path) {
   if (platform === 'web') {
     const css = encodeCSSStyleSheet(stylesheet)
     const preparedCss = `\n${css}ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
+    const formattedCss = t.stringLiteral(preparedCss)
+    // TODO: TODO
+    formattedCss.extra = { rawValue: preparedCss, raw: `"${preparedCss.split('\n').join(' \\n\\\n')}"` }
+
     const magicCssExpression = t.expressionStatement(
       t.callExpression(
         t.identifier('ZACS_MAGIC_CSS_STYLESHEET_MARKER_START'),
-        [t.templateLiteral([t.templateElement({ raw: preparedCss, cooked: preparedCss })], [])],
+        [formattedCss],
       ),
     )
     t.addComment(

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -736,6 +736,14 @@ function isPlainObjectProperty(t, node) {
   )
 }
 
+function isPlainTemplateLiteral(t, node) {
+  return (
+    t.isTemplateLiteral(node) &&
+    !node.expressions.length &&
+    node.quasis.length === 1
+  )
+}
+
 function validateStyleset(t, styleset, path) {
   if (
     !t.isObjectExpression(styleset) &&
@@ -751,7 +759,7 @@ function validateStyleset(t, styleset, path) {
       const key = property.key.name
       const { value } = property
       if (key === 'css') {
-        return t.isStringLiteral(value)
+        return t.isStringLiteral(value) ||isPlainTemplateLiteral(t, value)
       } else if (key === 'web' || key === 'native' || key === 'ios' || key === 'android') {
         validateStyleset(t, value, path)
         return true
@@ -808,7 +816,7 @@ function encodeCSSStyle(property) {
   if (key === 'native' || key === 'ios' || key === 'android') {
     return null
   } else if (key === 'css') {
-    return '  ' + value.value
+    return '  ' + (value.value || value.quasis[0].value.cooked)
   } else if (key === 'web') {
     return encodeCSSStyles(value)
   }

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -758,8 +758,15 @@ function encodeCSSProperty(property) {
   return property.name.replace(capitalRegex, cssCaseReplacer)
 }
 
+function encodeCSSValue(property, value) {
+  if (typeof value.value === 'number' && !unitlessCssAttributes.has(property.name)) {
+    return `${value.value}px`
+  }
+  return value.value
+}
+
 function encodeCSSStyle(property) {
-  return `  ${encodeCSSProperty(property.key)}: ${property.value.value};`
+  return `  ${encodeCSSProperty(property.key)}: ${encodeCSSValue(property.key, property.value)};`
 }
 
 function encodeCSSStyleset(styleset) {
@@ -1241,4 +1248,50 @@ const htmlElements = new Set([
   'variable',
   'video',
   'wbr',
+])
+
+const unitlessCssAttributes = new Set([
+  // Based on https://github.com/giuseppeg/style-sheet/blob/e71c119ecaccdb2e50be0759b45820b8cbf0c6df/src/data.js
+  'animationIterationCount',
+  'borderImageOutset',
+  'borderImageSlice',
+  'borderImageWidth',
+  'boxFlex',
+  'boxFlexGroup',
+  'boxOrdinalGroup',
+  'columnCount',
+  'columns',
+  'flex',
+  'flexGrow',
+  'flexPositive',
+  'flexShrink',
+  'flexNegative',
+  'flexOrder',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowSpan',
+  'gridRowStart',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnSpan',
+  'gridColumnStart',
+  'fontWeight',
+  'lineClamp',
+  'lineHeight',
+  'opacity',
+  'order',
+  'orphans',
+  'tabSize',
+  'widows',
+  'zIndex',
+  'zoom',
+  // SVG
+  'fillOpacity',
+  'floodOpacity',
+  'stopOpacity',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeMiterlimit',
+  'strokeOpacity',
+  'strokeWidth',
 ])

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -885,7 +885,10 @@ function transformStyleSheet(t, state, path) {
     const css = encodeCSSStyleSheet(stylesheet)
     const preparedCss = `\n${css}ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
     const formattedCss = t.stringLiteral(preparedCss)
-    // TODO: TODO
+    // NOTE: We can't use a template literal, because most people use a Babel transform for it, and it
+    // doesn't spit out clean output. So we spit out an ugly string literal, but keep it multi-line
+    // so that it's easier to view source code in case webpack fails to extract it.
+    // TODO: Escaped characters are probably broken here, please investigate
     formattedCss.extra = { rawValue: preparedCss, raw: `"${preparedCss.split('\n').join(' \\n\\\n')}"` }
 
     const magicCssExpression = t.expressionStatement(

--- a/src/webpack/__tests__/__snapshots__/test.js.snap
+++ b/src/webpack/__tests__/__snapshots__/test.js.snap
@@ -8,6 +8,11 @@ PRO TIP: If you get a ReferenceError on the line below, it means that your Webpa
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
 const styles = require(\\"../../../../.zacs-cache/src/webpack/__tests__/examples/basic.zacs.css\\")
+
+
+
+
+
 /* ZACS-generated CSS stylesheet ends above */
 
 zacs.view(styles.someName)

--- a/src/webpack/__tests__/__snapshots__/test.js.snap
+++ b/src/webpack/__tests__/__snapshots__/test.js.snap
@@ -32,3 +32,28 @@ exports[`zacs-loader extracts CSS 3`] = `
 "// extracted by mini-css-extract-plugin
 export const someName = \\"basic-zacs__someName\\";"
 `;
+
+exports[`zacs-loader extracts CSS with slightly malformed whitespace 1`] = `
+"/* eslint-disable */
+/*
+ZACS-generated CSS stylesheet begins below.
+PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
+If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
+*/
+const styles = require(\\"../../../../.zacs-cache/src/webpack/__tests__/examples/brokenWhitespace.zacs.css\\")
+
+
+
+
+
+
+
+
+
+
+
+/* ZACS-generated CSS stylesheet ends above */
+
+zacs.view(styles.someName)
+"
+`;

--- a/src/webpack/__tests__/examples/basic.js
+++ b/src/webpack/__tests__/examples/basic.js
@@ -4,12 +4,12 @@ ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
-const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`
 .someName {
   background-color: red;
   height: 100;
 }
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)
 /* ZACS-generated CSS stylesheet ends above */
 
 zacs.view(styles.someName)

--- a/src/webpack/__tests__/examples/basic.js
+++ b/src/webpack/__tests__/examples/basic.js
@@ -4,12 +4,12 @@ ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
-const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`
-.someName {
-  background-color: red;
-  height: 100;
-}
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(" \n\
+.someName { \n\
+  background-color: red; \n\
+  height: 100; \n\
+} \n\
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END")
 /* ZACS-generated CSS stylesheet ends above */
 
 zacs.view(styles.someName)

--- a/src/webpack/__tests__/examples/brokenMarker.js
+++ b/src/webpack/__tests__/examples/brokenMarker.js
@@ -1,3 +1,3 @@
 /* eslint-disable */
 
-const someoneJustPrankedMe = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`'
+const someoneJustPrankedMe = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`'

--- a/src/webpack/__tests__/examples/brokenMarker.js
+++ b/src/webpack/__tests__/examples/brokenMarker.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+const someoneJustPrankedMe = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`'

--- a/src/webpack/__tests__/examples/brokenMarker.js
+++ b/src/webpack/__tests__/examples/brokenMarker.js
@@ -1,3 +1,3 @@
 /* eslint-disable */
 
-const someoneJustPrankedMe = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`'
+const someoneJustPrankedMe = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START("'

--- a/src/webpack/__tests__/examples/brokenWhitespace.js
+++ b/src/webpack/__tests__/examples/brokenWhitespace.js
@@ -1,0 +1,21 @@
+/* eslint-disable */
+/*
+ZACS-generated CSS stylesheet begins below.
+PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
+If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
+*/
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(" \n\
+.someName { \n\
+  background-color: red; \n\
+  height: 100; \n\
+} \n\
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END"
+
+
+
+
+
+)
+/* ZACS-generated CSS stylesheet ends above */
+
+zacs.view(styles.someName)

--- a/src/webpack/__tests__/examples/multipleMarkers.js
+++ b/src/webpack/__tests__/examples/multipleMarkers.js
@@ -4,10 +4,10 @@ ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
-const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`
-.root {
-}
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(" \n\
+.root { \n\
+} \n\
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END")
 /* ZACS-generated CSS stylesheet ends above */
 
 /*
@@ -15,10 +15,10 @@ ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
-const styles2 = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`
-.someName {
-  background-color: red;
-  height: 100;
-}
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)
+const styles2 = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(" \n\
+.someName { \n\
+  background-color: red; \n\
+  height: 100; \n\
+} \n\
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END")
 /* ZACS-generated CSS stylesheet ends above */

--- a/src/webpack/__tests__/examples/multipleMarkers.js
+++ b/src/webpack/__tests__/examples/multipleMarkers.js
@@ -1,0 +1,24 @@
+/* eslint-disable */
+/*
+ZACS-generated CSS stylesheet begins below.
+PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
+If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
+*/
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`
+.root {
+}
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
+/* ZACS-generated CSS stylesheet ends above */
+
+/*
+ZACS-generated CSS stylesheet begins below.
+PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
+If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
+*/
+const styles2 = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`
+.someName {
+  background-color: red;
+  height: 100;
+}
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
+/* ZACS-generated CSS stylesheet ends above */

--- a/src/webpack/__tests__/examples/multipleMarkers.js
+++ b/src/webpack/__tests__/examples/multipleMarkers.js
@@ -4,10 +4,10 @@ ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
-const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`
+const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`
 .root {
 }
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)
 /* ZACS-generated CSS stylesheet ends above */
 
 /*
@@ -15,10 +15,10 @@ ZACS-generated CSS stylesheet begins below.
 PRO TIP: If you get a ReferenceError on the line below, it means that your Webpack ZACS support is not configured properly.
 If you only see this comment and the one below in generated code, this is normal, nothing to worry about!
 */
-const styles2 = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`
+const styles2 = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`
 .someName {
   background-color: red;
   height: 100;
 }
-ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`
+ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)
 /* ZACS-generated CSS stylesheet ends above */

--- a/src/webpack/__tests__/test.js
+++ b/src/webpack/__tests__/test.js
@@ -107,4 +107,9 @@ describe('zacs-loader', () => {
     const cssShim = modules.find(m => m.rawRequest.endsWith('/basic.zacs.css'))._source._value
     expect(cssShim).toMatchSnapshot()
   })
+  it(`does not allow multiple stylesheets in one file`, async () => {
+    await expect(compile('examples/multipleMarkers.js')).rejects.toMatchObject({
+      message: expect.stringMatching('not allowed to have multiple'),
+    })
+  })
 })

--- a/src/webpack/__tests__/test.js
+++ b/src/webpack/__tests__/test.js
@@ -107,6 +107,15 @@ describe('zacs-loader', () => {
     const cssShim = modules.find(m => m.rawRequest.endsWith('/basic.zacs.css'))._source._value
     expect(cssShim).toMatchSnapshot()
   })
+  it(`extracts CSS with slightly malformed whitespace`, async () => {
+    // For some reason, babel can insert unexpected whitespace in the generated marked CSS
+    const stats = await compile('examples/brokenWhitespace.js')
+    const { modules } = stats.compilation
+    expect(modules.length).toBe(3)
+
+    const js = modules.find(m => m.rawRequest === './examples/brokenWhitespace.js')._source._value
+    expect(js).toMatchSnapshot()
+  })
   it(`does not allow multiple stylesheets in one file`, async () => {
     await expect(compile('examples/multipleMarkers.js')).rejects.toMatchObject({
       message: expect.stringMatching('not allowed to have multiple'),

--- a/src/webpack/__tests__/test.js
+++ b/src/webpack/__tests__/test.js
@@ -112,4 +112,9 @@ describe('zacs-loader', () => {
       message: expect.stringMatching('not allowed to have multiple'),
     })
   })
+  it(`fails on broken stylesheet markers`, async () => {
+    await expect(compile('examples/brokenMarker.js')).rejects.toMatchObject({
+      message: expect.stringMatching('Broken ZACS stylesheet'),
+    })
+  })
 })

--- a/src/webpack/__tests__/test.js
+++ b/src/webpack/__tests__/test.js
@@ -117,4 +117,6 @@ describe('zacs-loader', () => {
       message: expect.stringMatching('Broken ZACS stylesheet'),
     })
   })
+  // TODO: e2e test (from source code to end result) with a more realistic setup.
+  // further babel plugins may mess up formatting of the magic markers breaking webpack
 })

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -30,7 +30,6 @@ function writeFileIfChanged(outputFilename, cssText) {
 }
 
 const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START("'
-const endMarker = ''
 
 exports.default = function loader(source, inputSourceMap) {
   // TODO: Options
@@ -46,16 +45,8 @@ exports.default = function loader(source, inputSourceMap) {
     this.emitError(`It's not allowed to have multiple \`zacs.stylesheet()\`s in a single JavaScript file`)
   }
 
-  // const stylesheetEndPos = source.indexOf(endMarker)
-  // if (stylesheetEndPos < stylesheetMarkerPos) {
-  //   this.emitError(`Broken ZACS stylesheet. Found the beginning of it, but the end is missing or malformed.`)
-  // }
-
-  // // NOTE: Avoiding regex for perf (probably unnecessarily :))
-  // const extractedStyles = source.substring(stylesheetMarkerPos, stylesheetEndPos + endMarker.length)
-  // const cssText = source.substring(stylesheetMarkerPos + startMarker.length, stylesheetEndPos)
-  //   .replace(/ \\n\\/g, '')
-
+  // NOTE: We can't use simple indexOf + substring, because some Babel plugins malform the magic markers, insterting whitespace
+  // between end of string argument and the closing paren
   const match = source.match(/ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\("(.*)ZACS_MAGIC_CSS_STYLESHEET_MARKER_END"\s*\)/s)
   if (!match) {
     this.emitError(`Broken ZACS stylesheet. Found the beginning of it, but the end is missing or malformed.`)

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -32,7 +32,7 @@ function writeFileIfChanged(outputFilename, cssText) {
 const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`'
 const endMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`'
 
-exports.default = function loader(source) {
+exports.default = function loader(source, inputSourceMap) {
   // TODO: Options
   // const options = getOptions(this)
 
@@ -79,7 +79,7 @@ exports.default = function loader(source) {
   this.callback(
     null,
     cleanSource,
-    // TODO: source map
+    inputSourceMap,
   )
   return undefined
 }

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -30,7 +30,7 @@ function writeFileIfChanged(outputFilename, cssText) {
 }
 
 const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START("'
-const endMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_END")'
+const endMarker = ''
 
 exports.default = function loader(source, inputSourceMap) {
   // TODO: Options
@@ -46,15 +46,23 @@ exports.default = function loader(source, inputSourceMap) {
     this.emitError(`It's not allowed to have multiple \`zacs.stylesheet()\`s in a single JavaScript file`)
   }
 
-  const stylesheetEndPos = source.indexOf(endMarker)
-  if (stylesheetEndPos < stylesheetMarkerPos) {
+  // const stylesheetEndPos = source.indexOf(endMarker)
+  // if (stylesheetEndPos < stylesheetMarkerPos) {
+  //   this.emitError(`Broken ZACS stylesheet. Found the beginning of it, but the end is missing or malformed.`)
+  // }
+
+  // // NOTE: Avoiding regex for perf (probably unnecessarily :))
+  // const extractedStyles = source.substring(stylesheetMarkerPos, stylesheetEndPos + endMarker.length)
+  // const cssText = source.substring(stylesheetMarkerPos + startMarker.length, stylesheetEndPos)
+  //   .replace(/ \\n\\/g, '')
+
+  const match = source.match(/ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\("(.*)ZACS_MAGIC_CSS_STYLESHEET_MARKER_END"\)/s)
+  if (!match) {
     this.emitError(`Broken ZACS stylesheet. Found the beginning of it, but the end is missing or malformed.`)
   }
 
-  // NOTE: Avoiding regex for perf (probably unnecessarily :))
-  const extractedStyles = source.substring(stylesheetMarkerPos, stylesheetEndPos + endMarker.length)
-  const cssText = source.substring(stylesheetMarkerPos + startMarker.length, stylesheetEndPos)
-    .replace(/ \\n\\/g, '')
+  const extractedStyles = match[0]
+  const cssText = match[1].replace(/ \\n\\/g, '')
 
   // TODO: Linaria checks for workspace/learna root -- see if it's needed here
   const root = /* workspaceRoot || lernaRoot || */ process.cwd()

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -56,7 +56,7 @@ exports.default = function loader(source, inputSourceMap) {
   // const cssText = source.substring(stylesheetMarkerPos + startMarker.length, stylesheetEndPos)
   //   .replace(/ \\n\\/g, '')
 
-  const match = source.match(/ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\("(.*)ZACS_MAGIC_CSS_STYLESHEET_MARKER_END"\)/s)
+  const match = source.match(/ZACS_MAGIC_CSS_STYLESHEET_MARKER_START\("(.*)ZACS_MAGIC_CSS_STYLESHEET_MARKER_END"\s*\)/s)
   if (!match) {
     this.emitError(`Broken ZACS stylesheet. Found the beginning of it, but the end is missing or malformed.`)
   }

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -29,8 +29,8 @@ function writeFileIfChanged(outputFilename, cssText) {
   }
 }
 
-const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START`'
-const endMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`'
+const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`'
+const endMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)'
 
 exports.default = function loader(source, inputSourceMap) {
   // TODO: Options

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -29,8 +29,8 @@ function writeFileIfChanged(outputFilename, cssText) {
   }
 }
 
-const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(`'
-const endMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_END`)'
+const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START("'
+const endMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_END")'
 
 exports.default = function loader(source, inputSourceMap) {
   // TODO: Options
@@ -54,6 +54,7 @@ exports.default = function loader(source, inputSourceMap) {
   // NOTE: Avoiding regex for perf (probably unnecessarily :))
   const extractedStyles = source.substring(stylesheetMarkerPos, stylesheetEndPos + endMarker.length)
   const cssText = source.substring(stylesheetMarkerPos + startMarker.length, stylesheetEndPos)
+    .replace(/ \\n\\/g, '')
 
   // TODO: Linaria checks for workspace/learna root -- see if it's needed here
   const root = /* workspaceRoot || lernaRoot || */ process.cwd()


### PR DESCRIPTION
- Clean up, error handling, improving code quality towards production, etc.
- add `px` to generated CSS where needed
- generate React Native stylesheets
- much improved validation, higher quality error messages (+ tests)
- allow web/native/ios/android/css syntax for platform-specific styles
- do work so that (hopefully) the webpack plugin doesn't mess up source maps

next step is to start testing on a real-world playground and find all the issues I've missed in test env