### PR TITLE
Stylesheet3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 
 .vscode
 .zacs-cache
+.zacs-cache-test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-8",
+  "version": "1.1.0-9",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-10",
+  "version": "1.1.0-13",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-9",
+  "version": "1.1.0-10",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -25,6 +25,7 @@ const styles = ZACS_RN_StyleSheet.create({
     width: '100%',
     flex: 1,
     zIndex: -1000,
+    zIndex: -2,
     width: 1337
   },
   text: {
@@ -51,6 +52,7 @@ const styles = ZACS_RN_StyleSheet.create({
     width: '100%',
     flex: 1,
     zIndex: -1000,
+    zIndex: -2,
     width: 1337,
     opacity: 0.1
   },
@@ -78,6 +80,7 @@ const styles = ZACS_RN_StyleSheet.create({
     width: '100%',
     flex: 1,
     zIndex: -1000,
+    zIndex: -2,
     width: 1337,
     // check replacement by babel
     width: 2137
@@ -108,6 +111,7 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\\" \\\\n\\\\
   width: 100%; \\\\n\\\\
   flex: 1; \\\\n\\\\
   z-index: -1000; \\\\n\\\\
+  z-index: -2; \\\\n\\\\
   -webkit-padding-start: 20px; \\\\n\\\\
   z-index: 1500; \\\\n\\\\
   & > span { opacity: 0.5 } \\\\n\\\\

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -110,6 +110,10 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\\" \\\\n\\\\
   -webkit-padding-start: 20px; \\\\n\\\\
   z-index: 1500; \\\\n\\\\
   & > span { opacity: 0.5 } \\\\n\\\\
+  & > div { \\\\n\\\\
+    margin: 20px; \\\\n\\\\
+    opacity: 0.5; \\\\n\\\\
+  } \\\\n\\\\
 } \\\\n\\\\
  \\\\n\\\\
 .text { \\\\n\\\\
@@ -124,6 +128,13 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\\" \\\\n\\\\
       color: #abbaba; \\\\n\\\\
     } \\\\n\\\\
 } \\\\n\\\\
+ \\\\n\\\\
+ \\\\n\\\\
+  @keyframes hello { \\\\n\\\\
+    from { opacity: 0 } \\\\n\\\\
+    to { opacity: 0 } \\\\n\\\\
+  } \\\\n\\\\
+   \\\\n\\\\
 ZACS_MAGIC_CSS_STYLESHEET_MARKER_END\\");
 /* ZACS-generated CSS stylesheet ends above */"
 `;

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -24,7 +24,7 @@ const styles = ZACS_RN_StyleSheet.create({
     height: 50,
     width: '100%',
     flex: 1,
-    zIndex: 1000,
+    zIndex: -1000,
     width: 1337
   },
   text: {
@@ -50,7 +50,7 @@ const styles = ZACS_RN_StyleSheet.create({
     height: 50,
     width: '100%',
     flex: 1,
-    zIndex: 1000,
+    zIndex: -1000,
     width: 1337,
     opacity: 0.1
   },
@@ -77,7 +77,7 @@ const styles = ZACS_RN_StyleSheet.create({
     height: 50,
     width: '100%',
     flex: 1,
-    zIndex: 1000,
+    zIndex: -1000,
     width: 1337,
     width: 2137
   },
@@ -106,12 +106,12 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\\" \\\\n\\\\
   height: 50px; \\\\n\\\\
   width: 100%; \\\\n\\\\
   flex: 1; \\\\n\\\\
-  z-index: 1000; \\\\n\\\\
+  z-index: -1000; \\\\n\\\\
   -webkit-padding-start: 20px; \\\\n\\\\
   z-index: 1500; \\\\n\\\\
   & > span { opacity: 0.5 } \\\\n\\\\
   & > div { \\\\n\\\\
-    margin: 20px; \\\\n\\\\
+    margin: -20px; \\\\n\\\\
     opacity: 0.5; \\\\n\\\\
   } \\\\n\\\\
 } \\\\n\\\\

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -79,6 +79,7 @@ const styles = ZACS_RN_StyleSheet.create({
     flex: 1,
     zIndex: -1000,
     width: 1337,
+    // check replacement by babel
     width: 2137
   },
   text: {

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -6,11 +6,13 @@ const styles = zacs._experimentalStyleSheet({
     backgroundColor: 'red',
     height: 50,
     width: '100%',
-    // check emulated mixin
-    ...{
-      flex: 1,
-      zIndex: -1000,
-    },
+    // check emulated mixins
+    // ...{
+    //   flex: 1,
+    //   zIndex: -1000,
+    // },
+    _mixin: { flex: 1, zIndex: -1000 },
+    _mixin: { zIndex: -2 },
     // native-only
     native: {
       width: 1337,

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -22,6 +22,10 @@ const styles = zacs._experimentalStyleSheet({
       opacity: 0.1,
     },
     css: '& > span { opacity: 0.5 }',
+    '& > div': {
+      margin: 20,
+      opacity: 0.5,
+    }
   },
   text: {
     color: '#abcdef',

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -16,7 +16,7 @@ const styles = zacs._experimentalStyleSheet({
       width: 1337,
     },
     ios: {
-      width: 2137,
+      width: REPLACE_INTO_NUMBER,
     },
     android: {
       opacity: 0.1,

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -35,4 +35,10 @@ const styles = zacs._experimentalStyleSheet({
       color: #abbaba;
     }`,
   },
+  css: `
+  @keyframes hello {
+    from { opacity: 0 }
+    to { opacity: 0 }
+  }
+  `,
 })

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -6,20 +6,26 @@ const styles = zacs._experimentalStyleSheet({
     backgroundColor: 'red',
     height: 50,
     width: '100%',
-    flex: 1,
-    zIndex: -1000,
-    web: {
-      WebkitPaddingStart: 20,
-      zIndex: 1500,
+    // check emulated mixin
+    ...{
+      flex: 1,
+      zIndex: -1000,
     },
+    // native-only
     native: {
       width: 1337,
     },
     ios: {
+      // check replacement by babel
       width: REPLACE_INTO_NUMBER,
     },
     android: {
       opacity: 0.1,
+    },
+    // web-only
+    web: {
+      WebkitPaddingStart: 20,
+      zIndex: 1500,
     },
     css: '& > span { opacity: 0.5 }',
     '& > div': {

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -7,7 +7,7 @@ const styles = zacs._experimentalStyleSheet({
     height: 50,
     width: '100%',
     flex: 1,
-    zIndex: 1000,
+    zIndex: -1000,
     web: {
       WebkitPaddingStart: 20,
       zIndex: 1500,
@@ -23,7 +23,7 @@ const styles = zacs._experimentalStyleSheet({
     },
     css: '& > span { opacity: 0.5 }',
     '& > div': {
-      margin: 20,
+      margin: -20,
       opacity: 0.5,
     }
   },

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -127,8 +127,8 @@ describe('zacs', () => {
     bad('{css: {}}', 'magic css:')
 
     bad('{a: {[name]:0}}', 'simple strings')
-    bad('{a: {foo:0,...styles}}', 'simple strings')
     bad('{a: {foo}}', 'simple strings')
+    bad('{a: {foo:0,...styles}}', 'Spread element')
     bad('{a: {"foo":0}}', 'web inner styles')
 
     bad('{a: {css:null}}', 'magic css:')
@@ -138,7 +138,7 @@ describe('zacs', () => {
     bad('{a: {css:`foo${bar}`}}', 'magic css:')
 
     bad('{a: {web:{foo}}}', 'simple strings')
-    bad('{a: {native:{...styles}}}', 'simple strings')
+    bad('{a: {native:{...styles}}}', 'Spread element')
     bad('{a: {ios:{foo}}}', 'simple strings')
     bad('{a: {android:{foo}}}', 'simple strings')
 

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -86,7 +86,10 @@ describe('zacs', () => {
     expect(transform(example('stylesheet'), 'native', { target: 'android' })).toMatchSnapshot()
   })
   it(`throw an error on illegal stylesheets`, () => {
-    const bad = (syntax, error) => expect(() => transform(`const _ = zacs._experimentalStyleSheet(${syntax})`, 'web')).toThrow(error)
+    const bad = (syntax, error) =>
+      expect(() => transform(`const _ = zacs._experimentalStyleSheet(${syntax})`, 'web')).toThrow(
+        error,
+      )
 
     bad('', 'single Object')
     bad('[]', 'single Object')
@@ -104,6 +107,8 @@ describe('zacs', () => {
     bad('{a: styles}', 'object literal')
     bad('{a: []}', 'object literal')
     bad('{a: ""}', 'object literal')
+
+    bad('{css: {}}', 'magic css:')
 
     bad('{a: {"foo":0}}', 'simple strings')
     bad('{a: {[name]:0}}', 'simple strings')

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -110,10 +110,10 @@ describe('zacs', () => {
 
     bad('{css: {}}', 'magic css:')
 
-    bad('{a: {"foo":0}}', 'simple strings')
     bad('{a: {[name]:0}}', 'simple strings')
     bad('{a: {foo:0,...styles}}', 'simple strings')
     bad('{a: {foo}}', 'simple strings')
+    bad('{a: {"foo":0}}', 'web inner styles')
 
     bad('{a: {css:null}}', 'magic css:')
     bad('{a: {css:predefinedCss}}', 'magic css:')

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -127,8 +127,8 @@ describe('zacs', () => {
     bad('{css: {}}', 'magic css:')
 
     bad('{a: {[name]:0}}', 'simple strings')
+    bad('{a: {foo:0,...styles}}', 'simple strings')
     bad('{a: {foo}}', 'simple strings')
-    bad('{a: {foo:0,...styles}}', 'Spread element')
     bad('{a: {"foo":0}}', 'web inner styles')
 
     bad('{a: {css:null}}', 'magic css:')
@@ -138,7 +138,7 @@ describe('zacs', () => {
     bad('{a: {css:`foo${bar}`}}', 'magic css:')
 
     bad('{a: {web:{foo}}}', 'simple strings')
-    bad('{a: {native:{...styles}}}', 'Spread element')
+    bad('{a: {native:{...styles}}}', 'simple strings')
     bad('{a: {ios:{foo}}}', 'simple strings')
     bad('{a: {android:{foo}}}', 'simple strings')
 

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -3,10 +3,26 @@ const path = require('path')
 const fs = require('fs')
 const plugin = require('../index')
 
+function testBabelPlugin(pluginBabel) {
+  const { types: t } = pluginBabel
+
+  return {
+    name: 'test-plugin',
+    visitor: {
+      Identifier(p) {
+        if (p.node.name === 'REPLACE_INTO_NUMBER') {
+          p.replaceWith(t.numericLiteral(2137))
+        }
+      },
+    },
+  }
+}
+
+
 function transform(input, platform, extra = {}) {
   const { code } = babel.transform(input, {
     configFile: false,
-    plugins: ['@babel/plugin-syntax-jsx', [plugin, { platform, ...extra }]],
+    plugins: ['@babel/plugin-syntax-jsx', [plugin, { platform, ...extra }], testBabelPlugin],
   })
   return code
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -67,6 +67,33 @@ type ZacsCreateStyledFunction = <Props>(
 
 type WhitelistedPropNames = Array<'ref' | 'zacs:inherit' | 'zacs:style' | string>
 
+type ZacsStylesheetStylesetWeb = $Exact<{
+  [ReactNativeStyleAttributeName | CSSPropertyName]: string | number,
+  ... // TODO: web nested
+}>
+
+type ZacsStylesheetStylesetNative = $Exact<{
+  [ReactNativeStyleAttributeName]: string | number,
+}>
+
+type ZacsStylesheetStyleset = $Exact<{
+  [ReactNativeStyleAttributeName | CSSPropertyName]: string | number,
+  native?: ZacsStylesheetStylesetNative,
+  ios?: ZacsStylesheetStylesetNative,
+  android?: ZacsStylesheetStylesetNative,
+  web?: ZacsStylesheetStylesetWeb,
+  css?: string,
+  ... // TODO: web nested
+}>
+
+type ZacsStylesheet = $Exact<{
+  [string]: ZacsStylesheetStyleset,
+  css?: string,
+}>
+
+// TODO: Fix return type
+type ZacsStylesheetFunction = (ZacsStylesheet) => $Exact<{ [string]: string }>
+
 declare export default {
   // TODO: Return components with the right prop types typed out (inherit prop types from component being styles + add conditionalStyles & style attributes)
   view: ZacsViewFunction,
@@ -75,6 +102,7 @@ declare export default {
   createView: ZacsCreateViewFunction,
   createText: ZacsCreateTextFunction,
   createStyled: ZacsCreateStyledFunction,
+  _experimentalStyleSheet: ZacsStylesheetFunction,
 }
 
 type ReactNativeStyleAttributeName =

--- a/src/webpack/__tests__/__snapshots__/test.js.snap
+++ b/src/webpack/__tests__/__snapshots__/test.js.snap
@@ -20,7 +20,8 @@ zacs.view(styles.someName)
 `;
 
 exports[`zacs-loader extracts CSS 2`] = `
-"
+"/* Generated CSS file (from ZACS Stylesheets) - do not edit! */
+
 .basic-zacs__someName {
   background-color: red;
   height: 100;
@@ -56,4 +57,9 @@ const styles = require(\\"../../../../.zacs-cache/src/webpack/__tests__/examples
 
 zacs.view(styles.someName)
 "
+`;
+
+exports[`zacs-loader has configurable cache directory and extension 1`] = `
+"// extracted by mini-css-extract-plugin
+export const someName = \\"basic-zacstest__someName\\";"
 `;

--- a/src/webpack/__tests__/test.js
+++ b/src/webpack/__tests__/test.js
@@ -103,7 +103,6 @@ describe('zacs-loader', () => {
 
     const css = modules.find(m => m.constructor.name === 'CssModule').content
     expect(css).toMatchSnapshot()
-
     const cssShim = modules.find(m => m.rawRequest.endsWith('/basic.zacs.css'))._source._value
     expect(cssShim).toMatchSnapshot()
   })
@@ -115,6 +114,17 @@ describe('zacs-loader', () => {
 
     const js = modules.find(m => m.rawRequest === './examples/brokenWhitespace.js')._source._value
     expect(js).toMatchSnapshot()
+  })
+  it(`has configurable cache directory and extension`, async () => {
+    const stats = await compile('examples/basic.js', {
+      cacheDirectory: path.resolve(__dirname, '.zacs-cache-test'),
+      extension: '.zacstest.css',
+    })
+    const { modules } = stats.compilation
+    expect(modules.length).toBe(3)
+
+    const cssShim = modules.find(m => m.rawRequest.endsWith('../.zacs-cache-test/src/webpack/__tests__/examples/basic.zacstest.css'))._source._value
+    expect(cssShim).toMatchSnapshot()
   })
   it(`does not allow multiple stylesheets in one file`, async () => {
     await expect(compile('examples/multipleMarkers.js')).rejects.toMatchObject({

--- a/src/webpack/loader.js
+++ b/src/webpack/loader.js
@@ -30,10 +30,10 @@ function writeFileIfChanged(outputFilename, cssText) {
 }
 
 const startMarker = 'ZACS_MAGIC_CSS_STYLESHEET_MARKER_START("'
+const cssDisclaimer = '/* Generated CSS file (from ZACS Stylesheets) - do not edit! */\n'
 
 exports.default = function loader(source, inputSourceMap) {
-  // TODO: Options
-  // const options = getOptions(this)
+  const { cacheDirectory = '.zacs-cache', extension = '.zacs.css' } = loaderUtils.getOptions(this) || {}
 
   const stylesheetMarkerPos = source.indexOf(startMarker)
   if (stylesheetMarkerPos === -1) {
@@ -53,12 +53,11 @@ exports.default = function loader(source, inputSourceMap) {
   }
 
   const extractedStyles = match[0]
-  const cssText = match[1].replace(/ \\n\\/g, '')
+  const cssText = cssDisclaimer + match[1].replace(/ \\n\\/g, '')
 
   // TODO: Linaria checks for workspace/learna root -- see if it's needed here
   const root = /* workspaceRoot || lernaRoot || */ process.cwd()
-  const cacheDirectory = '.zacs-cache' // TODO: Make configurable?
-  const baseOutputFileName = this.resourcePath.replace(/\.[^.]+$/, '.zacs.css')
+  const baseOutputFileName = this.resourcePath.replace(/\.[^.]+$/, extension)
   const outputFilename = normalize(
     path.join(
       path.isAbsolute(cacheDirectory) ? cacheDirectory : path.join(process.cwd(), cacheDirectory),


### PR DESCRIPTION
- Make webpack loader configurable (in particular, allow to change extracted CSS folder)
- Add disclaimer to generated CSS
- Allow `css: 'foo'` syntax on the style set list (for defining animation key frames and other syntax that's not nested under a selector)
- Allow nested selectors syntax, e.g. `root: { "&:hover": { opacity: 0.5 } }`