### PR TITLE
Stylesheet4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-13",
+  "version": "1.1.0-14",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-14",
+  "version": "1.1.0-16",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nozbe/zacs",
-  "version": "1.1.0-16",
+  "version": "1.1.0-17",
   "description": "Zero Abstraction Cost Styling (for React DOM and React Native)",
   "main": "src/index.js",
   "scripts": {

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -36,7 +36,9 @@ const styles = ZACS_RN_StyleSheet.create({
     fontWeight: 'bold',
     paddingLeft: 20,
     paddingRight: 20,
-    opacity: 0.5
+    opacity: 0.5,
+    // web-only postcss syntax
+    backgroundColor: '@theme(onSurface1)'
   }
 });"
 `;
@@ -67,7 +69,24 @@ const styles = ZACS_RN_StyleSheet.create({
     fontWeight: 'bold',
     paddingLeft: 20,
     paddingRight: 20,
-    opacity: 0.5
+    opacity: 0.5,
+    // web-only postcss syntax
+    backgroundColor: '@theme(onSurface1)'
+  }
+});"
+`;
+
+exports[`zacs transforms experimental stylesheets (native, android) 2`] = `
+"const zacsReactNative = require('react-native');
+
+const ZACS_RN_StyleSheet = zacsReactNative.StyleSheet;
+
+/* eslint-disable */
+const styles = ZACS_RN_StyleSheet.create({
+  text: {
+    // magic syntax for babel replacement plugins
+    backgroundColor: Styling.colors.onSurface1,
+    backgroundColor: Styling.colors.onSurface2
   }
 });"
 `;
@@ -99,7 +118,9 @@ const styles = ZACS_RN_StyleSheet.create({
     fontWeight: 'bold',
     paddingLeft: 20,
     paddingRight: 20,
-    opacity: 0.5
+    opacity: 0.5,
+    // web-only postcss syntax
+    backgroundColor: '@theme(onSurface1)'
   }
 });"
 `;
@@ -136,6 +157,7 @@ const styles = ZACS_MAGIC_CSS_STYLESHEET_MARKER_START(\\" \\\\n\\\\
   padding-left: 20px; \\\\n\\\\
   padding-right: 20px; \\\\n\\\\
   opacity: 0.5; \\\\n\\\\
+  background-color: @theme(onSurface1); \\\\n\\\\
   &:hover { \\\\n\\\\
       opacity: .8; \\\\n\\\\
       color: #abbaba; \\\\n\\\\

--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -26,7 +26,9 @@ const styles = ZACS_RN_StyleSheet.create({
     flex: 1,
     zIndex: -1000,
     zIndex: -2,
-    width: 1337
+    width: 1337,
+    // check native-only expressions
+    backgroundColor: foo ? rgba(a, b) : bar
   },
   text: {
     color: '#abcdef',
@@ -54,7 +56,10 @@ const styles = ZACS_RN_StyleSheet.create({
     zIndex: -1000,
     zIndex: -2,
     width: 1337,
-    opacity: 0.1
+    // check native-only expressions
+    backgroundColor: foo ? rgba(a, b) : bar,
+    opacity: 0.1,
+    marginVertical: foo(0)
   },
   text: {
     color: '#abcdef',
@@ -82,8 +87,11 @@ const styles = ZACS_RN_StyleSheet.create({
     zIndex: -1000,
     zIndex: -2,
     width: 1337,
+    // check native-only expressions
+    backgroundColor: foo ? rgba(a, b) : bar,
     // check replacement by babel
-    width: 2137
+    width: 2137,
+    marginHorizontal: foo(0)
   },
   text: {
     color: '#abcdef',

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -16,13 +16,17 @@ const styles = zacs._experimentalStyleSheet({
     // native-only
     native: {
       width: 1337,
+      // check native-only expressions
+      backgroundColor: foo ? rgba(a, b) : bar,
     },
     ios: {
       // check replacement by babel
       width: REPLACE_INTO_NUMBER,
+      marginHorizontal: foo(0),
     },
     android: {
       opacity: 0.1,
+      marginVertical: foo(0),
     },
     // web-only
     web: {

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -46,6 +46,8 @@ const styles = zacs._experimentalStyleSheet({
     paddingLeft: 20,
     paddingRight: 20,
     opacity: 0.5,
+    // web-only postcss syntax
+    backgroundColor: '@theme(onSurface1)',
     css: `&:hover {
       opacity: .8;
       color: #abbaba;

--- a/src/babel/__tests__/examples/stylesheet.js
+++ b/src/babel/__tests__/examples/stylesheet.js
@@ -51,7 +51,7 @@ const styles = zacs._experimentalStyleSheet({
       color: #abbaba;
     }`,
   },
-  css: `
+  css: zacs.css`
   @keyframes hello {
     from { opacity: 0 }
     to { opacity: 0 }

--- a/src/babel/__tests__/examples/stylesheetNative.js
+++ b/src/babel/__tests__/examples/stylesheetNative.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+import zacs from 'zacs'
+
+const styles = zacs._experimentalStyleSheet({
+  text: {
+    // magic syntax for babel replacement plugins
+    backgroundColor: ZACS_STYLESHEET_LITERAL(Styling.colors.onSurface1),
+    android: {
+      backgroundColor: ZACS_STYLESHEET_LITERAL(Styling.colors.onSurface2),
+    }
+  },
+})

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -100,6 +100,7 @@ describe('zacs', () => {
   })
   it(`transforms experimental stylesheets (native, android)`, () => {
     expect(transform(example('stylesheet'), 'native', { target: 'android' })).toMatchSnapshot()
+    expect(transform(example('stylesheetNative'), 'native', { target: 'android' })).toMatchSnapshot()
   })
   it(`throw an error on illegal stylesheets`, () => {
     const bad = (syntax, error) =>

--- a/src/babel/__tests__/test.js
+++ b/src/babel/__tests__/test.js
@@ -147,5 +147,8 @@ describe('zacs', () => {
     bad('{a: { width: null }}', 'strings or numbers')
     bad('{a: { width: false }}', 'strings or numbers')
     bad('{a: { width: foo(bar) }}', 'strings or numbers')
+
+    bad('{a: {native:{ios:{}}}}', 'nested')
+    bad('{a: {web:{web:{}}}}', 'nested')
   })
 })

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -803,6 +803,10 @@ function validateStyleset(t, styleset, nestedIn) {
     } else if (key === '_mixin') {
       validateStyleset(t, valuePath, nestedIn)
     } else if (key === 'web' || key === 'native' || key === 'ios' || key === 'android') {
+      if (nestedIn) {
+        throw property.buildCodeFrameError("ZACS StyleSheets cannot have platform-specific blocks nested within a platform-specific block")
+      }
+
       validateStyleset(t, valuePath, key)
     } else {
       const nestedInNative = nestedIn === 'native' || nestedIn === 'ios' || nestedIn === 'android'

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -666,12 +666,12 @@ function validateElementHasNoIllegalAttributes(t, path) {
   const { attributes } = openingElement
   if (hasAttrNamed(t, 'style', attributes)) {
     throw path.buildCodeFrameError(
-      "It's not allowed to pass `style` attribute to ZACS-styled components",
+      'It\'s not allowed to pass `style` attribute to ZACS-styled components',
     )
   }
   if (hasAttrNamed(t, 'className', attributes)) {
     throw path.buildCodeFrameError(
-      "It's not allowed to pass `className` attribute to ZACS-styled components",
+      'It\'s not allowed to pass `className` attribute to ZACS-styled components',
     )
   }
 }
@@ -686,7 +686,7 @@ function validateZacsImport(t, path) {
     )
   ) {
     throw path.buildCodeFrameError(
-      "ZACS import must say exactly `import zacs from '@nozbe/zacs'`. Other forms such as `import { view, text }`, `require`, `import * as zacs` are not allowed.",
+      'ZACS import must say exactly `import zacs from \'@nozbe/zacs\'`. Other forms such as `import { view, text }`, `require`, `import * as zacs` are not allowed.',
     )
   }
 }
@@ -731,13 +731,10 @@ function transformZacsAttributesOnNonZacsElement(t, platform, path) {
 }
 
 function isPlainObjectProperty(t, node, allowStringLiterals) {
-  const isAllowedKey = t.isIdentifier(node.key) || (allowStringLiterals && t.isStringLiteral(node.key))
+  const isAllowedKey =
+    t.isIdentifier(node.key) || (allowStringLiterals && t.isStringLiteral(node.key))
   return (
-    t.isObjectProperty(node) &&
-    isAllowedKey &&
-    !node.shorthand &&
-    !node.computed &&
-    !node.method
+    t.isObjectProperty(node) && isAllowedKey && !node.shorthand && !node.computed && !node.method
   )
 }
 
@@ -746,13 +743,19 @@ function isPlainTemplateLiteral(t, node) {
 }
 
 function isNumberLiteral(t, node) {
-  return t.isNumericLiteral(node) || (t.isUnaryExpression(node) && node.operator === '-' && node.prefix && t.isNumericLiteral(node.argument))
+  return (
+    t.isNumericLiteral(node) ||
+    (t.isUnaryExpression(node) &&
+      node.operator === '-' &&
+      node.prefix &&
+      t.isNumericLiteral(node.argument))
+  )
 }
 
 function validateStyleset(t, styleset, nestedIn) {
   if (!t.isObjectExpression(styleset.node)) {
     throw styleset.buildCodeFrameError(
-      "ZACS StyleSheets must be simple object literals, like so: `text: { backgroundColor: 'red', height: 100 }`. Other syntaxes, like `foo ? {xxx} : {yyy}` or `...styles` are not allowed.",
+      'ZACS StyleSheets must be simple object literals, like so: `text: { backgroundColor: \'red\', height: 100 }`. Other syntaxes, like `foo ? {xxx} : {yyy}` or `...styles` are not allowed.',
     )
   }
 
@@ -785,7 +788,7 @@ function validateStyleset(t, styleset, nestedIn) {
     if (t.isStringLiteral(property.node.key)) {
       if (!t.isObjectExpression(value)) {
         throw styleset.buildCodeFrameError(
-          "ZACS StyleSheets style attributes must be simple strings, like so: `{ backgroundColor: \'red\', height: 100 }`. Quoted keys are only allowed for web inner styles, e.g. `{ \"& > span\": { opacity: 0.5 } }`",
+          'ZACS StyleSheets style attributes must be simple strings, like so: `{ backgroundColor: \'red\', height: 100 }`. Quoted keys are only allowed for web inner styles, e.g. `{ "& > span": { opacity: 0.5 } }`',
         )
       }
       validateStyleset(t, valuePath, 'web')
@@ -797,14 +800,16 @@ function validateStyleset(t, styleset, nestedIn) {
     if (key === 'css') {
       if (!(t.isStringLiteral(value) || isPlainTemplateLiteral(t, value))) {
         throw valuePath.buildCodeFrameError(
-          "ZACS StyleSheet's magic css: property expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.",
+          'ZACS StyleSheet\'s magic css: property expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.',
         )
       }
     } else if (key === '_mixin') {
       validateStyleset(t, valuePath, nestedIn)
     } else if (key === 'web' || key === 'native' || key === 'ios' || key === 'android') {
       if (nestedIn) {
-        throw property.buildCodeFrameError("ZACS StyleSheets cannot have platform-specific blocks nested within a platform-specific block")
+        throw property.buildCodeFrameError(
+          'ZACS StyleSheets cannot have platform-specific blocks nested within a platform-specific block',
+        )
       }
 
       validateStyleset(t, valuePath, key)
@@ -812,7 +817,7 @@ function validateStyleset(t, styleset, nestedIn) {
       const nestedInNative = nestedIn === 'native' || nestedIn === 'ios' || nestedIn === 'android'
       if (!(t.isStringLiteral(value) || isNumberLiteral(t, value)) && !nestedInNative) {
         throw valuePath.buildCodeFrameError(
-          "ZACS StyleSheet's style values must be simple literal strings or numbers, e.g.: `backgroundColor: 'red'`, or `height: 100.`. Compound expressions, references, and other syntaxes are not allowed",
+          'ZACS StyleSheet\'s style values must be simple literal strings or numbers, e.g.: `backgroundColor: \'red\'`, or `height: 100.`. Compound expressions, references, and other syntaxes are not allowed',
         )
       }
     }
@@ -837,7 +842,7 @@ function validateStyleSheet(t, path) {
       const cssValue = styleset.get('value')
       if (!(t.isStringLiteral(cssValue.node) || isPlainTemplateLiteral(t, cssValue.node))) {
         throw cssValue.buildCodeFrameError(
-          "ZACS StyleSheet's magic css: styleset expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.",
+          'ZACS StyleSheet\'s magic css: styleset expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.',
         )
       }
     } else {

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -1183,6 +1183,21 @@ exports.default = function(babel) {
           path.remove()
         }
       },
+      TaggedTemplateExpression(path) {
+        const { node } = path
+        const { tag } = node
+        if (
+          !(
+            t.isMemberExpression(tag) &&
+            t.isIdentifier(tag.object, { name: 'zacs' }) &&
+            t.isIdentifier(tag.property, { name: 'css' })
+          )
+        ) {
+          return
+        }
+
+        path.replaceWith(node.quasi)
+      },
     },
   }
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -103,7 +103,7 @@ declare export default {
   createText: ZacsCreateTextFunction,
   createStyled: ZacsCreateStyledFunction,
   _experimentalStyleSheet: ZacsStylesheetFunction,
-  css: string => string,
+  css: (_strings: string[], ..._exprs: Array<any>) => string,
 }
 
 type ReactNativeStyleAttributeName =

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -103,6 +103,7 @@ declare export default {
   createText: ZacsCreateTextFunction,
   createStyled: ZacsCreateStyledFunction,
   _experimentalStyleSheet: ZacsStylesheetFunction,
+  css: string => string,
 }
 
 type ReactNativeStyleAttributeName =


### PR DESCRIPTION
- Allow arbitrary expressions within native: blocks (they don't have to be compile-time constant literals, since we don't need to be able to statically convert that to CSS)
- Improved validation: disallow nesting of platform blocks
- Add 'zacs.css`xxx`' tagged template literal (noop for syntax highlighting)
- add ZACS_STYLESHEET_LITERAL(foo), which simply signals to the validator to allow any expression for that value and not complain. this is needed for dynamic color replacement (Styling.zcolor.xxx) in NT