### PR TITLE
Fix generation for literal styles with non-identifier keys

### DIFF
--- a/src/babel/__tests__/__snapshots__/test.js.snap
+++ b/src/babel/__tests__/__snapshots__/test.js.snap
@@ -250,6 +250,10 @@ const added1_two = <ZACS_RN_View style={{
 const added1_literals = <ZACS_RN_View style={{
   width: 500,
   backgroundColor: \\"#abcdef\\"
+}} __zacs_original_name=\\"AddedStyles1\\" />;
+const added1_propKeys = <ZACS_RN_View style={{
+  \\"--background\\": \\"white\\",
+  1: 1
 }} __zacs_original_name=\\"AddedStyles1\\" />; // check with null
 
 const addedNull = <ZACS_RN_View __zacs_original_name=\\"AddedStylesNull\\" onPress={onPress} />;
@@ -470,6 +474,10 @@ const added1_two = <div style={{
 const added1_literals = <div style={{
   width: 500,
   backgroundColor: \\"#abcdef\\"
+}} __zacs_original_name=\\"AddedStyles1\\" />;
+const added1_propKeys = <div style={{
+  \\"--background\\": \\"white\\",
+  1: 1
 }} __zacs_original_name=\\"AddedStyles1\\" />; // check with null
 
 const addedNull = <div __zacs_original_name=\\"AddedStylesNull\\" />;

--- a/src/babel/__tests__/examples/basic.js
+++ b/src/babel/__tests__/examples/basic.js
@@ -103,6 +103,8 @@ const condNull = <ConditionalNull onPress={onPress} />
 const AddedStyles1 = zacs.view(null, null, {
   width: 'width',
   color: 'backgroundColor',
+  background: '--background',
+  one: 1,
 })
 
 const added1_none = <AddedStyles1 />
@@ -110,6 +112,8 @@ const added1_one = <AddedStyles1 width={width} />
 const added1_two = <AddedStyles1 width={width} color={factoryColor(color)} />
 
 const added1_literals = <AddedStyles1 width={500} color="#abcdef" />
+
+const added1_propKeys = <AddedStyles1 background="white" one={1} />
 
 // check with null
 

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -172,9 +172,20 @@ function jsxAttr(t, name, value) {
   return t.jSXAttribute(t.jSXIdentifier(name), t.jSXExpressionContainer(value))
 }
 
+const identifierRegex = /^[a-zA-Z][a-zA-Z0-9]*$/
+function objectKey(t, key) {
+  if (typeof key === 'string' && identifierRegex.test(key)) {
+    return t.identifier(key)
+  } else if (typeof key === 'number') {
+    return t.numericLiteral(key)
+  } else {
+    return t.stringLiteral(String(key))
+  }
+}
+
 function objectExpressionFromPairs(t, keyValuePairs) {
   return t.objectExpression(
-    keyValuePairs.map(([key, value]) => t.objectProperty(t.identifier(key), value)),
+    keyValuePairs.map(([key, value]) => t.objectProperty(objectKey(t, key), value)),
   )
 }
 
@@ -666,12 +677,12 @@ function validateElementHasNoIllegalAttributes(t, path) {
   const { attributes } = openingElement
   if (hasAttrNamed(t, 'style', attributes)) {
     throw path.buildCodeFrameError(
-      'It\'s not allowed to pass `style` attribute to ZACS-styled components',
+      "It's not allowed to pass `style` attribute to ZACS-styled components",
     )
   }
   if (hasAttrNamed(t, 'className', attributes)) {
     throw path.buildCodeFrameError(
-      'It\'s not allowed to pass `className` attribute to ZACS-styled components',
+      "It's not allowed to pass `className` attribute to ZACS-styled components",
     )
   }
 }
@@ -686,7 +697,7 @@ function validateZacsImport(t, path) {
     )
   ) {
     throw path.buildCodeFrameError(
-      'ZACS import must say exactly `import zacs from \'@nozbe/zacs\'`. Other forms such as `import { view, text }`, `require`, `import * as zacs` are not allowed.',
+      "ZACS import must say exactly `import zacs from '@nozbe/zacs'`. Other forms such as `import { view, text }`, `require`, `import * as zacs` are not allowed.",
     )
   }
 }
@@ -755,13 +766,15 @@ function isNumberLiteral(t, node) {
 // ZACS_STYLESHEET_LITERAL(xxx) - magic syntax that passes validation
 // for use by babel plugins that transform dynamic expressions into static literals
 function isZacsStyleSheetLiteral(t, node) {
-  return (t.isCallExpression(node) && t.isIdentifier(node.callee, { name: 'ZACS_STYLESHEET_LITERAL' }))
+  return (
+    t.isCallExpression(node) && t.isIdentifier(node.callee, { name: 'ZACS_STYLESHEET_LITERAL' })
+  )
 }
 
 function validateStyleset(t, styleset, nestedIn) {
   if (!t.isObjectExpression(styleset.node)) {
     throw styleset.buildCodeFrameError(
-      'ZACS StyleSheets must be simple object literals, like so: `text: { backgroundColor: \'red\', height: 100 }`. Other syntaxes, like `foo ? {xxx} : {yyy}` or `...styles` are not allowed.',
+      "ZACS StyleSheets must be simple object literals, like so: `text: { backgroundColor: 'red', height: 100 }`. Other syntaxes, like `foo ? {xxx} : {yyy}` or `...styles` are not allowed.",
     )
   }
 
@@ -785,7 +798,7 @@ function validateStyleset(t, styleset, nestedIn) {
 
     if (!isPlainObjectProperty(t, property.node, true)) {
       throw property.buildCodeFrameError(
-        'ZACS StyleSheets style attributes must be simple strings, like so: `{ backgroundColor: \'red\', height: 100 }`. Other syntaxes, like `[propName]:` are not allowed.',
+        "ZACS StyleSheets style attributes must be simple strings, like so: `{ backgroundColor: 'red', height: 100 }`. Other syntaxes, like `[propName]:` are not allowed.",
       )
     }
     const valuePath = property.get('value')
@@ -806,7 +819,7 @@ function validateStyleset(t, styleset, nestedIn) {
     if (key === 'css') {
       if (!(t.isStringLiteral(value) || isPlainTemplateLiteral(t, value))) {
         throw valuePath.buildCodeFrameError(
-          'ZACS StyleSheet\'s magic css: property expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.',
+          "ZACS StyleSheet's magic css: property expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.",
         )
       }
     } else if (key === '_mixin') {
@@ -821,9 +834,16 @@ function validateStyleset(t, styleset, nestedIn) {
       validateStyleset(t, valuePath, key)
     } else {
       const nestedInNative = nestedIn === 'native' || nestedIn === 'ios' || nestedIn === 'android'
-      if (!(t.isStringLiteral(value) || isNumberLiteral(t, value) || isZacsStyleSheetLiteral(t, value)) && !nestedInNative) {
+      if (
+        !(
+          t.isStringLiteral(value) ||
+          isNumberLiteral(t, value) ||
+          isZacsStyleSheetLiteral(t, value)
+        ) &&
+        !nestedInNative
+      ) {
         throw valuePath.buildCodeFrameError(
-          'ZACS StyleSheet\'s style values must be simple literal strings or numbers, e.g.: `backgroundColor: \'red\'`, or `height: 100.`. Compound expressions, references, and other syntaxes are not allowed',
+          "ZACS StyleSheet's style values must be simple literal strings or numbers, e.g.: `backgroundColor: 'red'`, or `height: 100.`. Compound expressions, references, and other syntaxes are not allowed",
         )
       }
     }
@@ -848,7 +868,7 @@ function validateStyleSheet(t, path) {
       const cssValue = styleset.get('value')
       if (!(t.isStringLiteral(cssValue.node) || isPlainTemplateLiteral(t, cssValue.node))) {
         throw cssValue.buildCodeFrameError(
-          'ZACS StyleSheet\'s magic css: styleset expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.',
+          "ZACS StyleSheet's magic css: styleset expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.",
         )
       }
     } else {

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -179,8 +179,7 @@ function objectKey(t, key) {
   } else if (typeof key === 'number') {
     return t.numericLiteral(key)
   }
-    return t.stringLiteral(String(key))
-
+  return t.stringLiteral(String(key))
 }
 
 function objectExpressionFromPairs(t, keyValuePairs) {

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -178,9 +178,9 @@ function objectKey(t, key) {
     return t.identifier(key)
   } else if (typeof key === 'number') {
     return t.numericLiteral(key)
-  } else {
-    return t.stringLiteral(String(key))
   }
+    return t.stringLiteral(String(key))
+
 }
 
 function objectExpressionFromPairs(t, keyValuePairs) {
@@ -677,12 +677,12 @@ function validateElementHasNoIllegalAttributes(t, path) {
   const { attributes } = openingElement
   if (hasAttrNamed(t, 'style', attributes)) {
     throw path.buildCodeFrameError(
-      "It's not allowed to pass `style` attribute to ZACS-styled components",
+      'It\'s not allowed to pass `style` attribute to ZACS-styled components',
     )
   }
   if (hasAttrNamed(t, 'className', attributes)) {
     throw path.buildCodeFrameError(
-      "It's not allowed to pass `className` attribute to ZACS-styled components",
+      'It\'s not allowed to pass `className` attribute to ZACS-styled components',
     )
   }
 }
@@ -697,7 +697,7 @@ function validateZacsImport(t, path) {
     )
   ) {
     throw path.buildCodeFrameError(
-      "ZACS import must say exactly `import zacs from '@nozbe/zacs'`. Other forms such as `import { view, text }`, `require`, `import * as zacs` are not allowed.",
+      'ZACS import must say exactly `import zacs from \'@nozbe/zacs\'`. Other forms such as `import { view, text }`, `require`, `import * as zacs` are not allowed.',
     )
   }
 }
@@ -774,7 +774,7 @@ function isZacsStyleSheetLiteral(t, node) {
 function validateStyleset(t, styleset, nestedIn) {
   if (!t.isObjectExpression(styleset.node)) {
     throw styleset.buildCodeFrameError(
-      "ZACS StyleSheets must be simple object literals, like so: `text: { backgroundColor: 'red', height: 100 }`. Other syntaxes, like `foo ? {xxx} : {yyy}` or `...styles` are not allowed.",
+      'ZACS StyleSheets must be simple object literals, like so: `text: { backgroundColor: \'red\', height: 100 }`. Other syntaxes, like `foo ? {xxx} : {yyy}` or `...styles` are not allowed.',
     )
   }
 
@@ -798,7 +798,7 @@ function validateStyleset(t, styleset, nestedIn) {
 
     if (!isPlainObjectProperty(t, property.node, true)) {
       throw property.buildCodeFrameError(
-        "ZACS StyleSheets style attributes must be simple strings, like so: `{ backgroundColor: 'red', height: 100 }`. Other syntaxes, like `[propName]:` are not allowed.",
+        'ZACS StyleSheets style attributes must be simple strings, like so: `{ backgroundColor: \'red\', height: 100 }`. Other syntaxes, like `[propName]:` are not allowed.',
       )
     }
     const valuePath = property.get('value')
@@ -819,7 +819,7 @@ function validateStyleset(t, styleset, nestedIn) {
     if (key === 'css') {
       if (!(t.isStringLiteral(value) || isPlainTemplateLiteral(t, value))) {
         throw valuePath.buildCodeFrameError(
-          "ZACS StyleSheet's magic css: property expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.",
+          'ZACS StyleSheet\'s magic css: property expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.',
         )
       }
     } else if (key === '_mixin') {
@@ -843,7 +843,7 @@ function validateStyleset(t, styleset, nestedIn) {
         !nestedInNative
       ) {
         throw valuePath.buildCodeFrameError(
-          "ZACS StyleSheet's style values must be simple literal strings or numbers, e.g.: `backgroundColor: 'red'`, or `height: 100.`. Compound expressions, references, and other syntaxes are not allowed",
+          'ZACS StyleSheet\'s style values must be simple literal strings or numbers, e.g.: `backgroundColor: \'red\'`, or `height: 100.`. Compound expressions, references, and other syntaxes are not allowed',
         )
       }
     }
@@ -868,7 +868,7 @@ function validateStyleSheet(t, path) {
       const cssValue = styleset.get('value')
       if (!(t.isStringLiteral(cssValue.node) || isPlainTemplateLiteral(t, cssValue.node))) {
         throw cssValue.buildCodeFrameError(
-          "ZACS StyleSheet's magic css: styleset expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.",
+          'ZACS StyleSheet\'s magic css: styleset expects a simple literal string as its value. Object expressions, references, expressions in a template literal are not allowed.',
         )
       }
     } else {


### PR DESCRIPTION
The previous logic seemed to break the styles, if you tried to create a literal style that would try to bind a value that wasn't translatable to a `t.identifier` type in Babel. Consider a case, where:

```js
const Root = zacs.view(style.root, null, { background: '--bg-color' })
<Root background="white" />
```

would be turned into something like this:

```js
const generatedStyle = {
  // Oops...
  --bg-color: "white"
}
```

This resulted in an error thrown, if the platform was set to `native`.


